### PR TITLE
Add "\r" to Utils.c/strip().

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -212,7 +212,7 @@ void strip(char *s)
     size_t offset = 0;
     for(i = 0; i < len; ++i){
         char c = s[i];
-        if(c==' '||c=='\t'||c=='\n') ++offset;
+        if(c==' '||c=='\t'||c=='\n'||c=='\r') ++offset;
         else s[i-offset] = c;
     }
     s[len-offset] = '\0';


### PR DESCRIPTION
This will be needed for windows users.