### PR TITLE
Adding OS detection to Makefile and flags to proper linking on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ LDFLAGS= -lm -pthread -lstdc++
 COMMON= 
 CFLAGS=-Wall -Wfatal-errors 
 
+# Detect OS
+uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
+
 ifeq ($(DEBUG), 1) 
 OPTS=-O0 -g
 endif
@@ -32,6 +35,9 @@ ifeq ($(GPU), 1)
 COMMON+= -DGPU -I/usr/local/cuda/include/
 CFLAGS+= -DGPU
 LDFLAGS+= -L/usr/local/cuda/lib64 -lcuda -lcudart -lcublas -lcurand
+ifeq ($(uname_S),Darwin)
+LDFLAGS+= -F/Library/Frameworks -framework CUDA -rpath /Library/Frameworks -rpath /usr/local/cuda/lib
+endif
 endif
 
 OBJ=gemm.o utils.o cuda.o deconvolutional_layer.o convolutional_layer.o list.o image.o activations.o im2col.o col2im.o blas.o crop_layer.o dropout_layer.o maxpool_layer.o softmax_layer.o data.o matrix.o network.o connected_layer.o cost_layer.o parser.o option_list.o darknet.o detection_layer.o imagenet.o captcha.o route_layer.o writing.o box.o nightmare.o normalization_layer.o avgpool_layer.o coco.o dice.o yolo.o layer.o compare.o classifier.o local_layer.o swag.o shortcut_layer.o activation_layer.o rnn_layer.o rnn.o


### PR DESCRIPTION
This adds a check for the OS, and fixes the linking on OSX where the CUDA framework is used and rpath is set so the dynamic linker won't complain.