### PR TITLE
Make GPU option compatible with modern GCC/ CUDA by enabling -D_FORCE_INLINES for NVCC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ ifeq ($(GPU), 1)
 COMMON+= -DGPU -I/usr/local/cuda/include/
 CFLAGS+= -DGPU
 LDFLAGS+= -L/usr/local/cuda/lib64 -lcuda -lcudart -lcublas -lcurand
+CUDA_NVCC_FLAGS+= -D_FORCE_INLINES
 endif
 
 ifeq ($(CUDNN), 1) 
@@ -59,7 +60,7 @@ $(OBJDIR)%.o: %.c $(DEPS)
 	$(CC) $(COMMON) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR)%.o: %.cu $(DEPS)
-	$(NVCC) $(ARCH) $(COMMON) --compiler-options "$(CFLAGS)" -c $< -o $@
+	$(NVCC) $(ARCH) $(COMMON) --compiler-options "$(CFLAGS)" -c $< -o $@ $(CUDA_NVCC_FLAGS)
 
 obj:
 	mkdir -p obj


### PR DESCRIPTION
This fixes the compile errors that will occur when using enabling GPU acceleration on a modern (e.g. Ubuntu 15.10+) Linux installation.