### PR TITLE
add eps inside the sqrt()

### DIFF
--- a/src/blas.c
+++ b/src/blas.c
@@ -96,7 +96,7 @@ void normalize_cpu(float *x, float *mean, float *variance, int batch, int filter
         for(f = 0; f < filters; ++f){
             for(i = 0; i < spatial; ++i){
                 int index = b*filters*spatial + f*spatial + i;
-                x[index] = (x[index] - mean[f])/(sqrt(variance[f]) + .000001f);
+                x[index] = (x[index] - mean[f])/(sqrt(variance[f] + .000001f));
             }
         }
     }


### PR DESCRIPTION
The paper adds epsilon before applying the square root. Doesn't make a huge difference but its inconsistent what other CNN engines do so I think it makes sense to fix this.