### PR TITLE
Fixed duplicate cuda_free in layer.c

### DIFF
--- a/src/layer.c
+++ b/src/layer.c
@@ -31,9 +31,7 @@ void free_layer(layer l)
     if(l.weights_gpu)          cuda_free(l.weights_gpu);
     if(l.weight_updates_gpu)   cuda_free(l.weight_updates_gpu);
     if(l.col_image_gpu)        cuda_free(l.col_image_gpu);
-    if(l.weights_gpu)          cuda_free(l.weights_gpu);
     if(l.biases_gpu)           cuda_free(l.biases_gpu);
-    if(l.weight_updates_gpu)   cuda_free(l.weight_updates_gpu);
     if(l.bias_updates_gpu)     cuda_free(l.bias_updates_gpu);
     if(l.output_gpu)           cuda_free(l.output_gpu);
     if(l.delta_gpu)            cuda_free(l.delta_gpu);


### PR DESCRIPTION
Two of the arrays that are part of each layer are freed twice with calls to `cuda_free` in `layer.c`.  This patch removes the unnecessary calls to fix crashes on some platforms due to undefined behavior (tested on NVIDIA Jetson TX1 with Ubuntu 14.04, OpenCV 2, gcc 4.8, CUDA 7.0).