### PR TITLE
Fix region layer name

### DIFF
--- a/src/region_layer.c
+++ b/src/region_layer.c
@@ -42,7 +42,7 @@ layer make_region_layer(int batch, int w, int h, int n, int classes, int coords)
     l.delta_gpu = cuda_make_array(l.delta, batch*l.outputs);
 #endif
 
-    fprintf(stderr, "detection\n");
+    fprintf(stderr, "region\n");
     srand(0);
 
     return l;


### PR DESCRIPTION
The region layer is currently called `detection`. This renames it to `region`.