### PR TITLE
Fixed OpenCV Compilation Errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-GPU=1
-CUDNN=1
-OPENCV=1
+GPU=0
+CUDNN=0
+OPENCV=0
 DEBUG=0
 
 ARCH= -gencode arch=compute_20,code=[sm_20,sm_21] \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-GPU=0
-CUDNN=0
-OPENCV=0
+GPU=1
+CUDNN=1
+OPENCV=1
 DEBUG=0
 
 ARCH= -gencode arch=compute_20,code=[sm_20,sm_21] \

--- a/src/art.c
+++ b/src/art.c
@@ -8,6 +8,7 @@
 
 #ifdef OPENCV
 #include "opencv2/highgui/highgui_c.h"
+#include "opencv2/videoio/videoio_c.h"
 image get_image_from_stream(CvCapture *cap);
 #endif
 

--- a/src/classifier.c
+++ b/src/classifier.c
@@ -10,6 +10,7 @@
 
 #ifdef OPENCV
 #include "opencv2/highgui/highgui_c.h"
+#include "opencv2/videoio/videoio_c.h"
 image get_image_from_stream(CvCapture *cap);
 #endif
 

--- a/src/demo.c
+++ b/src/demo.c
@@ -14,6 +14,7 @@
 #ifdef OPENCV
 #include "opencv2/highgui/highgui_c.h"
 #include "opencv2/imgproc/imgproc_c.h"
+#include "opencv2/videoio/videoio_c.h"
 image get_image_from_stream(CvCapture *cap);
 
 static char **demo_names;

--- a/src/image.c
+++ b/src/image.c
@@ -12,6 +12,7 @@
 
 #ifdef OPENCV
 #include "opencv2/highgui/highgui_c.h"
+#include "opencv2/videoio/videoio_c.h"
 #include "opencv2/imgproc/imgproc_c.h"
 #endif
 

--- a/src/rnn_vid.c
+++ b/src/rnn_vid.c
@@ -6,6 +6,7 @@
 
 #ifdef OPENCV
 #include "opencv2/highgui/highgui_c.h"
+#include "opencv2/videoio/videoio_c.h"
 image get_image_from_stream(CvCapture *cap);
 image ipl_to_image(IplImage* src);
 

--- a/src/voxel.c
+++ b/src/voxel.c
@@ -5,6 +5,7 @@
 
 #ifdef OPENCV
 #include "opencv2/highgui/highgui_c.h"
+#include "opencv2/videoio/videoio_c.h"
 image get_image_from_stream(CvCapture *cap);
 #endif
 


### PR DESCRIPTION
A few files were in need of an extra include file (namely, videoio_c.h) for the CvCapture.

Added the correct header to the following files:
    ./src/art.c
    ./src/classifier.c
    ./src/demo.c
    ./src/image.c
    ./src/rnn_vid.c
    ./src/voxel.c

This may solve some issues for those that run into the same problem and don't want to find how to fix each issue with videoio.