### PR TITLE
fix memory leak (network workspace)

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -601,4 +601,16 @@ void free_network(network net)
     if(net.input_gpu) free(net.input_gpu);
     if(net.truth_gpu) free(net.truth_gpu);
 #endif
+
+    if(net.workspace_size){
+#ifdef GPU
+        if(net.gpu_index >= 0){
+            cuda_free(net.workspace);
+        }else {
+            free(net.workspace);
+        }
+#else
+        free(net.workspace);
+#endif
+    }
 }

--- a/src/network.h
+++ b/src/network.h
@@ -13,6 +13,7 @@ typedef enum {
 
 typedef struct network{
     float *workspace;
+    size_t workspace_size;
     int n;
     int batch;
     int *seen;

--- a/src/parser.c
+++ b/src/parser.c
@@ -683,6 +683,7 @@ network parse_network_cfg(char *filename)
     free_list(sections);
     net.outputs = get_network_output_size(net);
     net.output = get_network_output(net);
+    net.workspace_size = workspace_size;
     if(workspace_size){
         //printf("%ld\n", workspace_size);
 #ifdef GPU


### PR DESCRIPTION
Fixed memory leak: free_network not deallocating network workspace buffer