### PR TITLE
Make NVCC happy on Ubuntu 16.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ $(OBJDIR)%.o: %.c $(DEPS)
 	$(CC) $(COMMON) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR)%.o: %.cu $(DEPS)
-	$(NVCC) $(ARCH) $(COMMON) --compiler-options "$(CFLAGS)" -c $< -o $@
+	$(NVCC) $(ARCH) $(COMMON) --compiler-options "-std=c++98 $(CFLAGS)" -c $< -o $@
 
 obj:
 	mkdir -p obj


### PR DESCRIPTION
Force to not use C++11 features to compile on newer Ubuntu versions.
Doesn't run without it. 
Unless I think you have changed which gcc Cuda uses. 