### PR TITLE
The window should be created before calling detect_in_thread

### DIFF
--- a/src/demo.c
+++ b/src/demo.c
@@ -131,6 +131,12 @@ void demo(char *cfgfile, char *weightfile, float thresh, int cam_index, const ch
     probs = (float **)calloc(l.w*l.h*l.n, sizeof(float *));
     for(j = 0; j < l.w*l.h*l.n; ++j) probs[j] = (float *)calloc(l.classes, sizeof(float));
 
+    if(!prefix){
+        cvNamedWindow("Demo", CV_WINDOW_NORMAL); 
+        cvMoveWindow("Demo", 0, 0);
+        cvResizeWindow("Demo", 1352, 1013);
+    }
+
     pthread_t fetch_thread;
     pthread_t detect_thread;
 
@@ -153,11 +159,6 @@ void demo(char *cfgfile, char *weightfile, float thresh, int cam_index, const ch
     }
 
     int count = 0;
-    if(!prefix){
-        cvNamedWindow("Demo", CV_WINDOW_NORMAL); 
-        cvMoveWindow("Demo", 0, 0);
-        cvResizeWindow("Demo", 1352, 1013);
-    }
 
     double before = get_wall_time();
 


### PR DESCRIPTION
Move cvNamedWindow and the parent block before calling detect_in_thread. Otherwise, draw_detections will be called in detect_in_thread before cvNamedWindow, and cvNamedWindow will later generate a segmentation fault. 

This bug can be recreated on my Ubuntu with GTX970 by process video with yolo9000.