### PR TITLE
Fix crash (SIGSEGV) on running ./darknet detect command

### DIFF
--- a/src/darknet.c
+++ b/src/darknet.c
@@ -9,7 +9,7 @@
 #include "connected_layer.h"
 
 extern void predict_classifier(char *datacfg, char *cfgfile, char *weightfile, char *filename, int top);
-extern void test_detector(char *datacfg, char *cfgfile, char *weightfile, char *filename, float thresh, float hier_thresh);
+extern void test_detector(char *datacfg, char *cfgfile, char *weightfile, char *filename, float thresh, float hier_thresh, char *outfile, int fullscreen);
 extern void run_voxel(int argc, char **argv);
 extern void run_yolo(int argc, char **argv);
 extern void run_detector(int argc, char **argv);
@@ -423,7 +423,9 @@ int main(int argc, char **argv)
     } else if (0 == strcmp(argv[1], "detect")){
         float thresh = find_float_arg(argc, argv, "-thresh", .24);
         char *filename = (argc > 4) ? argv[4]: 0;
-        test_detector("cfg/coco.data", argv[2], argv[3], filename, thresh, .5);
+        char *outfile = find_char_arg(argc, argv, "-out", 0);
+        int fullscreen = find_arg(argc, argv, "-fullscreen");
+        test_detector("cfg/coco.data", argv[2], argv[3], filename, thresh, .5, outfile, fullscreen);
     } else if (0 == strcmp(argv[1], "cifar")){
         run_cifar(argc, argv);
     } else if (0 == strcmp(argv[1], "go")){


### PR DESCRIPTION
The extern symbol of test_detector is wrong on darknet.c which leads to a SIGSEGV error on running ./darknet detect cfg/yolo.cfg yolo.weights data/dog.jpg

https://groups.google.com/forum/#!topic/darknet/wImTkjoMO2U
https://groups.google.com/forum/#!topic/darknet/pFeEZmpW9co

A lot of people got the same problem, I think this change should be merged to master. Thank you.