### PR TITLE
Fix bug that causes -(nan)ind and inaccurate output during training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ ehthumbs.db
 Icon?
 Thumbs.db
 *.swp
+/.vs/darknet3/v15/ipch/AutoPCH/a1a9de2f/DATA-c6754b5/DATA.ipch
+/.vs

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,3 @@ ehthumbs.db
 Icon?
 Thumbs.db
 *.swp
-/.vs/darknet3/v15/ipch/AutoPCH/a1a9de2f/DATA-c6754b5/DATA.ipch
-/.vs

--- a/src/data.c
+++ b/src/data.c
@@ -322,7 +322,8 @@ void fill_truth_detection(char *path, int num_boxes, float *truth, int classes, 
         h =  boxes[i].h;
         id = boxes[i].id;
 
-        if ((w < .001 || h < .001)) continue;
+        if ((w < .001 || h < .001)) 
+			x=-1;
 
         truth[i*5+0] = x;
         truth[i*5+1] = y;

--- a/src/region_layer.c
+++ b/src/region_layer.c
@@ -186,6 +186,8 @@ void forward_region_layer(const layer l, network net)
             for(t = 0; t < 30; ++t){
                 box truth = float_to_box(net.truth + t*5 + b*l.truths, 1);
                 if(!truth.x) break;
+				if (truth.x == -1)
+					continue;
                 int class = net.truth[t*5 + b*l.truths + 4];
                 float maxp = 0;
                 int maxi = 0;
@@ -222,6 +224,8 @@ void forward_region_layer(const layer l, network net)
                     for(t = 0; t < 30; ++t){
                         box truth = float_to_box(net.truth + t*5 + b*l.truths, 1);
                         if(!truth.x) break;
+						if (truth.x == -1)
+							continue;
                         float iou = box_iou(pred, truth);
                         if (iou > best_iou) {
                             best_iou = iou;
@@ -249,6 +253,8 @@ void forward_region_layer(const layer l, network net)
             box truth = float_to_box(net.truth + t*5 + b*l.truths, 1);
 
             if(!truth.x) break;
+			if (truth.x == -1)
+				continue;
             float best_iou = 0;
             int best_n = 0;
             i = (truth.x * l.w);


### PR DESCRIPTION
In the `fill_truth_detection` function of `data.c` , every box that is too small is set to 0. However, the `forward_region_layer` function in `region_layer.c` will treat 0 as the end of boxes and that will be a bug.

For example, an image that has a small bounding box may have `state.truth` look like this: [0,0,0,0,0,x,x,x,x,x.....] (x represents the normal data). The for loop of `forward_region_layer` will break at the first 0 data without running on the rest of it, which will causes `-(nan)ind` and inaccurate output during training, especially on custom dataset.

To fix this, I changed the code in `data.c` to set the small bounding boxes to -1 and added code in `region_layer.c` to continue the for loop when meet with -1. It solves the problem according to my test.