### PR TITLE
cuDNN function update for v6.0

### DIFF
--- a/src/convolutional_layer.c
+++ b/src/convolutional_layer.c
@@ -130,6 +130,8 @@ void cudnn_convolutional_setup(layer *l)
     cudnnSetTensor4dDescriptor(l->dstTensorDesc, CUDNN_TENSOR_NCHW, CUDNN_DATA_FLOAT, l->batch, l->out_c, l->out_h, l->out_w); 
     cudnnSetTensor4dDescriptor(l->normTensorDesc, CUDNN_TENSOR_NCHW, CUDNN_DATA_FLOAT, 1, l->out_c, 1, 1); 
     cudnnSetFilter4dDescriptor(l->weightDesc, CUDNN_DATA_FLOAT, CUDNN_TENSOR_NCHW, l->n, l->c, l->size, l->size); 
+    // For the newest cuDNN v6.0, use "cudnnSetConvolution2dDescriptor_v4" to replace "cudnnSetConvolution2dDescriptor" function
+    //cudnnSetConvolution2dDescriptor_v4(l->convDesc, l->pad, l->pad, l->stride, l->stride, 1, 1, CUDNN_CROSS_CORRELATION);
     cudnnSetConvolution2dDescriptor(l->convDesc, l->pad, l->pad, l->stride, l->stride, 1, 1, CUDNN_CROSS_CORRELATION);
     cudnnGetConvolutionForwardAlgorithm(cudnn_handle(),
             l->srcTensorDesc,


### PR DESCRIPTION
the function ”cudnnSetConvolution2dDescriptor“ has different arguments in cuDNN v6.0, in order to use the old arguments, change the function to cudnnSetConvolution2dDescriptor_v4