### PR TITLE
CLOCK_REALTIME not available in OSX, use clock_get_time

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -8,12 +8,31 @@
 #include <limits.h>
 #include <time.h>
 
+#ifdef __MACH__
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
+
 #include "utils.h"
 
 double what_time_is_it_now()
 {
     struct timespec now;
-    clock_gettime(CLOCK_REALTIME, &now);
+    
+    //https://gist.github.com/jbenet/1087739     
+    #ifdef __MACH__ // OS X does not have clock_gettime, use clock_get_time
+      clock_serv_t cclock;
+      mach_timespec_t mts;
+      host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+      clock_get_time(cclock, &mts);
+      mach_port_deallocate(mach_task_self(), cclock);
+      now.tv_sec = mts.tv_sec;
+      now.tv_nsec = mts.tv_nsec;
+    #else
+      clock_gettime(CLOCK_REALTIME, now);
+    #endif
+    
+    
     return now.tv_sec + now.tv_nsec*1e-9;
 }
 


### PR DESCRIPTION
I tried to compile Darknet in OSX and got this error:

    ./src/utils.c:16:19: fatal error: use of undeclared identifier 'CLOCK_REALTIME'
        clock_gettime(CLOCK_REALTIME, &now);

I was able to fixit reimplementing the **double what_time_is_it_now()** function in utils.c file.

My OSX version is:

    $ uname -a
    Darwin MacBook-Pro.local 15.6.0 Darwin Kernel Version 15.6.0: Tue Apr 11 16:00:51 PDT 2017; root:xnu-3248.60.11.5.3~1/RELEASE_X86_64 x86_64