### PR TITLE
nightmare: Fix segfault from double free() when GPU=0 and iters>=2.

### DIFF
--- a/examples/nightmare.c
+++ b/examples/nightmare.c
@@ -68,6 +68,7 @@ void optimize_picture(network *net, image orig, int max_layer, float scale, floa
     copy_cpu(last.outputs, last.output, 1, last.delta, 1);
     calculate_loss(last.output, last.delta, last.outputs, thresh);
     backward_network(*net);
+    net->input = NULL;
 #endif
 
     if(flip) flip_image(delta);


### PR DESCRIPTION
Please see [issue 85](https://github.com/pjreddie/darknet/issues/85) for a detailed description.