### PR TITLE
gemm_cpu(): Make the gemm_*() functions' inner loop iteration variables private to the OpenMP parallel regions. Fixes a segfault.

### DIFF
--- a/src/gemm.c
+++ b/src/gemm.c
@@ -77,7 +77,7 @@ void gemm_nn(int M, int N, int K, float ALPHA,
         float *C, int ldc)
 {
     int i,j,k;
-    #pragma omp parallel for
+    #pragma omp parallel for private(i,j,k)
     for(i = 0; i < M; ++i){
         for(k = 0; k < K; ++k){
             register float A_PART = ALPHA*A[i*lda+k];
@@ -94,7 +94,7 @@ void gemm_nt(int M, int N, int K, float ALPHA,
         float *C, int ldc)
 {
     int i,j,k;
-    #pragma omp parallel for
+    #pragma omp parallel for private(i,j,k)
     for(i = 0; i < M; ++i){
         for(j = 0; j < N; ++j){
             register float sum = 0;
@@ -112,7 +112,7 @@ void gemm_tn(int M, int N, int K, float ALPHA,
         float *C, int ldc)
 {
     int i,j,k;
-    #pragma omp parallel for
+    #pragma omp parallel for private(i,j,k)
     for(i = 0; i < M; ++i){
         for(k = 0; k < K; ++k){
             register float A_PART = ALPHA*A[k*lda+i];
@@ -129,7 +129,7 @@ void gemm_tt(int M, int N, int K, float ALPHA,
         float *C, int ldc)
 {
     int i,j,k;
-    #pragma omp parallel for
+    #pragma omp parallel for private(i,j,k)
     for(i = 0; i < M; ++i){
         for(j = 0; j < N; ++j){
             register float sum = 0;


### PR DESCRIPTION
Also to express my disgust about putting raisins in buns. They're like shriveled little creatures in there. Jesus christ