### PR TITLE
Update yolo.c to accept .jpeg extension

### DIFF
--- a/examples/yolo.c
+++ b/examples/yolo.c
@@ -241,6 +241,7 @@ void validate_yolo_recall(char *cfgfile, char *weightfile)
         find_replace(labelpath, "JPEGImages", "labels", labelpath);
         find_replace(labelpath, ".jpg", ".txt", labelpath);
         find_replace(labelpath, ".JPEG", ".txt", labelpath);
+        find_replace(labelpath, ".jpeg", ".txt", labelpath);
 
         int num_labels = 0;
         box_label *truth = read_boxes(labelpath, &num_labels);


### PR DESCRIPTION
if files have .jpeg extensions, darknet cannot find the label.txt during training...