### PR TITLE
Softmax

### DIFF
--- a/src/blas.c
+++ b/src/blas.c
@@ -267,13 +267,15 @@ void softmax(float *input, int n, float temp, int stride, float *output)
     for(i = 0; i < n; ++i){
         if(input[i*stride] > largest) largest = input[i*stride];
     }
+    float temp_inv = 1.0 / temp;
     for(i = 0; i < n; ++i){
-        float e = exp(input[i*stride]/temp - largest/temp);
+        float e = exp((input[i*stride] - largest) * temp_inv);
         sum += e;
         output[i*stride] = e;
     }
+    float sum_inv = 1.0 / sum;
     for(i = 0; i < n; ++i){
-        output[i*stride] /= sum;
+        output[i*stride] *= sum_inv;
     }
 }
 

--- a/src/blas.c
+++ b/src/blas.c
@@ -290,3 +290,24 @@ void softmax_cpu(float *input, int n, int batch, int batch_offset, int groups, i
     }
 }
 
+void backward_softmax(float *output, float *delta_output, int n, float temp, int stride, float *delta_input)
+{
+    int i;
+    float dot = dot_cpu(n, output, 1, delta_output, 1);
+    float temp_inv = 1.0 / temp;
+    for(i = 0; i < n; ++i){
+        delta_input[i] += temp_inv * output[i] * (delta_output[i] - dot);
+    }
+}
+
+void backward_softmax_cpu(float *output, float *delta_output, int n, int batch, int batch_offset, int groups, int group_offset, int stride, float temp, float *delta_input)
+{
+    int g, b;
+    int offset;
+    for(b = 0; b < batch; ++b){
+        for(g = 0; g < groups; ++g){
+            offset = b*batch_offset + g*group_offset;
+            backward_softmax(output + offset, delta_output + offset, n, temp, stride, delta_input + offset);
+        }
+    }
+}

--- a/src/blas.h
+++ b/src/blas.h
@@ -42,6 +42,9 @@ void weighted_delta_cpu(float *a, float *b, float *s, float *da, float *db, floa
 void softmax(float *input, int n, float temp, int stride, float *output);
 void softmax_cpu(float *input, int n, int batch, int batch_offset, int groups, int group_offset, int stride, float temp, float *output);
 
+void backward_softmax(float *output, float *delta_output, int n, float temp, int stride, float *delta_input);
+void backward_softmax_cpu(float *output, float *delta_output, int n, int batch, int batch_offset, int groups, int group_offset, int stride, float temp, float *delta_input);
+
 #ifdef GPU
 #include "cuda.h"
 #include "tree.h"
@@ -88,6 +91,7 @@ void deinter_gpu(int NX, float *X, int NY, float *Y, int B, float *OUT);
 void reorg_gpu(float *x, int w, int h, int c, int batch, int stride, int forward, float *out);
 
 void softmax_gpu(float *input, int n, int batch, int batch_offset, int groups, int group_offset, int stride, float temp, float *output);
+void backward_softmax_gpu(float *output, float *delta_output, int n, int batch, int batch_offset, int groups, int group_offset, int stride, float temp, float *delta_input);
 void adam_update_gpu(float *w, float *d, float *m, float *v, float B1, float B2, float eps, float decay, float rate, int n, int batch, int t);
 void adam_gpu(int n, float *x, float *m, float *v, float B1, float B2, float rate, float eps, int t);
 

--- a/src/blas_kernels.cu
+++ b/src/blas_kernels.cu
@@ -860,16 +860,17 @@ __device__ void softmax_device(float *input, int n, float temp, int stride, floa
     float sum = 0;
     float largest = -INFINITY;
     for(i = 0; i < n; ++i){
-        int val = input[i*stride];
-        largest = (val>largest) ? val : largest;
+        largest = (input[i*stride] > largest) ? input[i*stride] : largest;
     }
+    float temp_inv = 1.0 / temp;
     for(i = 0; i < n; ++i){
-        float e = exp(input[i*stride]/temp - largest/temp);
+        float e = exp((input[i*stride] - largest) * temp_inv);
         sum += e;
         output[i*stride] = e;
     }
+    float sum_inv = 1.0 / sum;
     for(i = 0; i < n; ++i){
-        output[i*stride] /= sum;
+        output[i*stride] *= sum_inv;
     }
 }
 

--- a/src/softmax_layer.c
+++ b/src/softmax_layer.c
@@ -44,7 +44,11 @@ void forward_softmax_layer(const softmax_layer l, network net)
             count += group_size;
         }
     } else {
-        softmax_cpu(net.input, l.inputs/l.groups, l.batch, l.inputs, l.groups, l.inputs/l.groups, 1, l.temperature, l.output);
+        if(l.spatial){
+            softmax_cpu(net.input, l.c, l.batch*l.c, l.inputs/l.c, l.w*l.h, 1, l.w*l.h, l.temperature, l.output);
+        }else{
+            softmax_cpu(net.input, l.inputs/l.groups, l.batch, l.inputs, l.groups, l.inputs/l.groups, 1, l.temperature, l.output);
+        }
     }
 }
 
@@ -59,7 +63,11 @@ void backward_softmax_layer(const softmax_layer l, network net)
             count += group_size;
         }
     } else {
-        backward_softmax_cpu(l.output, l.delta, l.inputs/l.groups, l.batch, l.inputs, l.groups, l.inputs/l.groups, 1, l.temperature, net.delta);
+        if(l.spatial){
+            backward_softmax_cpu(l.output, l.delta, l.c, l.batch*l.c, l.inputs/l.c, l.w*l.h, 1, l.w*l.h, l.temperature, net.delta);
+        } else {
+            backward_softmax_cpu(l.output, l.delta, l.inputs/l.groups, l.batch, l.inputs, l.groups, l.inputs/l.groups, 1, l.temperature, net.delta);
+        }
     }
 }
 
@@ -82,7 +90,7 @@ void forward_softmax_layer_gpu(const softmax_layer l, network net)
         }
     } else {
         if(l.spatial){
-            softmax_gpu(net.input_gpu, l.c, l.batch*l.c, l.inputs/l.c, l.w*l.h, 1, l.w*l.h, 1, l.output_gpu);
+            softmax_gpu(net.input_gpu, l.c, l.batch*l.c, l.inputs/l.c, l.w*l.h, 1, l.w*l.h, l.temperature, l.output_gpu);
         }else{
             softmax_gpu(net.input_gpu, l.inputs/l.groups, l.batch, l.inputs, l.groups, l.inputs/l.groups, 1, l.temperature, l.output_gpu);
         }
@@ -101,7 +109,7 @@ void backward_softmax_layer_gpu(const softmax_layer l, network net)
         }
     } else {
         if(l.spatial){
-            backward_softmax_gpu(l.output_gpu, l.delta_gpu, l.c, l.batch*l.c, l.inputs/l.c, l.w*l.h, 1, l.w*l.h, 1, net.delta_gpu);
+            backward_softmax_gpu(l.output_gpu, l.delta_gpu, l.c, l.batch*l.c, l.inputs/l.c, l.w*l.h, 1, l.w*l.h, l.temperature, net.delta_gpu);
         } else {
             backward_softmax_gpu(l.output_gpu, l.delta_gpu, l.inputs/l.groups, l.batch, l.inputs, l.groups, l.inputs/l.groups, 1, l.temperature, net.delta_gpu);
         }

--- a/src/softmax_layer.c
+++ b/src/softmax_layer.c
@@ -50,14 +50,24 @@ void forward_softmax_layer(const softmax_layer l, network net)
 
 void backward_softmax_layer(const softmax_layer l, network net)
 {
-    axpy_cpu(l.inputs*l.batch, 1, l.delta, 1, net.delta, 1);
+    if(l.softmax_tree){
+        int i;
+        int count = 0;
+        for(i = 0; i < l.softmax_tree->groups; ++i){
+            int group_size = l.softmax_tree->group_size[i];
+            backward_softmax_cpu(l.output + count, l.delta + count, group_size, l.batch, l.inputs, 1, 0, 1, l.temperature, net.delta + count);
+            count += group_size;
+        }
+    } else {
+        backward_softmax_cpu(l.output, l.delta, l.inputs/l.groups, l.batch, l.inputs, l.groups, l.inputs/l.groups, 1, l.temperature, net.delta);
+    }
 }
 
 #ifdef GPU
 
-void pull_softmax_layer_output(const softmax_layer layer)
+void pull_softmax_layer_output(const softmax_layer l)
 {
-    cuda_pull_array(layer.output_gpu, layer.output, layer.inputs*layer.batch);
+    cuda_pull_array(l.output_gpu, l.output, l.inputs*l.batch);
 }
 
 void forward_softmax_layer_gpu(const softmax_layer l, network net)
@@ -79,9 +89,23 @@ void forward_softmax_layer_gpu(const softmax_layer l, network net)
     }
 }
 
-void backward_softmax_layer_gpu(const softmax_layer layer, network net)
+void backward_softmax_layer_gpu(const softmax_layer l, network net)
 {
-    axpy_gpu(layer.batch*layer.inputs, 1, layer.delta_gpu, 1, net.delta_gpu, 1);
+    if(l.softmax_tree){
+        int i;
+        int count = 0;
+        for(i = 0; i < l.softmax_tree->groups; ++i){
+            int group_size = l.softmax_tree->group_size[i];
+            backward_softmax_gpu(l.output_gpu + count, l.delta_gpu + count, group_size, l.batch, l.inputs, 1, 0, 1, l.temperature, net.delta_gpu + count);
+            count += group_size;
+        }
+    } else {
+        if(l.spatial){
+            backward_softmax_gpu(l.output_gpu, l.delta_gpu, l.c, l.batch*l.c, l.inputs/l.c, l.w*l.h, 1, l.w*l.h, 1, net.delta_gpu);
+        } else {
+            backward_softmax_gpu(l.output_gpu, l.delta_gpu, l.inputs/l.groups, l.batch, l.inputs, l.groups, l.inputs/l.groups, 1, l.temperature, net.delta_gpu);
+        }
+    }
 }
 
 #endif

--- a/src/softmax_layer.h
+++ b/src/softmax_layer.h
@@ -5,7 +5,6 @@
 
 typedef layer softmax_layer;
 
-void softmax_array(float *input, int n, float temp, float *output);
 softmax_layer make_softmax_layer(int batch, int inputs, int groups);
 void forward_softmax_layer(const softmax_layer l, network net);
 void backward_softmax_layer(const softmax_layer l, network net);


### PR DESCRIPTION
Backward pass for softmax_layer was implemented incorrectly, by simply copying gradient w.r.t output into gradient w.r.t. input. 
Also, added spatial softmax functionality for CPU processing.