### PR TITLE
Fix crashing when running inferences with Yolo-9000 model.

### DIFF
--- a/examples/captcha.c
+++ b/examples/captcha.c
@@ -39,7 +39,7 @@ void train_captcha(char *cfgfile, char *weightfile)
     int i = *net.seen/imgs;
     int solved = 1;
     list *plist;
-    char **labels = get_labels("/data/captcha/reimgs.labels.list");
+    char **labels = get_labels("/data/captcha/reimgs.labels.list", NULL);
     if (solved){
         plist = get_paths("/data/captcha/reimgs.solved.list");
     }else{
@@ -102,7 +102,7 @@ void test_captcha(char *cfgfile, char *weightfile, char *filename)
     set_batch_network(&net, 1);
     srand(2222222);
     int i = 0;
-    char **names = get_labels("/data/captcha/reimgs.labels.list");
+    char **names = get_labels("/data/captcha/reimgs.labels.list", NULL);
     char buff[256];
     char *input = buff;
     int indexes[26];
@@ -135,7 +135,7 @@ void test_captcha(char *cfgfile, char *weightfile, char *filename)
 
 void valid_captcha(char *cfgfile, char *weightfile, char *filename)
 {
-    char **labels = get_labels("/data/captcha/reimgs.labels.list");
+    char **labels = get_labels("/data/captcha/reimgs.labels.list", NULL);
     network net = parse_network_cfg(cfgfile);
     if(weightfile){
         load_weights(&net, weightfile);

--- a/examples/cifar.c
+++ b/examples/cifar.c
@@ -16,7 +16,7 @@ void train_cifar(char *cfgfile, char *weightfile)
     int classes = 10;
     int N = 50000;
 
-    char **labels = get_labels("data/cifar/labels.txt");
+    char **labels = get_labels("data/cifar/labels.txt", NULL);
     int epoch = (*net.seen)/N;
     data train = load_all_cifar10();
     while(get_current_batch(net) < net.max_batches || net.max_batches == 0){
@@ -64,7 +64,7 @@ void train_cifar_distill(char *cfgfile, char *weightfile)
     int classes = 10;
     int N = 50000;
 
-    char **labels = get_labels("data/cifar/labels.txt");
+    char **labels = get_labels("data/cifar/labels.txt", NULL);
     int epoch = (*net.seen)/N;
 
     data train = load_all_cifar10();

--- a/examples/classifier.c
+++ b/examples/classifier.c
@@ -48,7 +48,7 @@ void train_classifier(char *datacfg, char *cfgfile, char *weightfile, int *gpus,
     char *train_list = option_find_str(options, "train", "data/train.list");
     int classes = option_find_int(options, "classes", 2);
 
-    char **labels = get_labels(label_list);
+    char **labels = get_labels(label_list, NULL);
     list *plist = get_paths(train_list);
     char **paths = (char **)list_to_array(plist);
     printf("%d\n", plist->size);
@@ -258,7 +258,7 @@ void validate_classifier_crop(char *datacfg, char *filename, char *weightfile)
     int classes = option_find_int(options, "classes", 2);
     int topk = option_find_int(options, "top", 1);
 
-    char **labels = get_labels(label_list);
+    char **labels = get_labels(label_list, NULL);
     list *plist = get_paths(valid_list);
 
     char **paths = (char **)list_to_array(plist);
@@ -326,7 +326,7 @@ void validate_classifier_10(char *datacfg, char *filename, char *weightfile)
     int classes = option_find_int(options, "classes", 2);
     int topk = option_find_int(options, "top", 1);
 
-    char **labels = get_labels(label_list);
+    char **labels = get_labels(label_list, NULL);
     list *plist = get_paths(valid_list);
 
     char **paths = (char **)list_to_array(plist);
@@ -398,7 +398,7 @@ void validate_classifier_full(char *datacfg, char *filename, char *weightfile)
     int classes = option_find_int(options, "classes", 2);
     int topk = option_find_int(options, "top", 1);
 
-    char **labels = get_labels(label_list);
+    char **labels = get_labels(label_list, NULL);
     list *plist = get_paths(valid_list);
 
     char **paths = (char **)list_to_array(plist);
@@ -461,7 +461,7 @@ void validate_classifier_single(char *datacfg, char *filename, char *weightfile)
     int classes = option_find_int(options, "classes", 2);
     int topk = option_find_int(options, "top", 1);
 
-    char **labels = get_labels(label_list);
+    char **labels = get_labels(label_list, NULL);
     list *plist = get_paths(valid_list);
 
     char **paths = (char **)list_to_array(plist);
@@ -521,7 +521,7 @@ void validate_classifier_multi(char *datacfg, char *filename, char *weightfile)
     int classes = option_find_int(options, "classes", 2);
     int topk = option_find_int(options, "top", 1);
 
-    char **labels = get_labels(label_list);
+    char **labels = get_labels(label_list, NULL);
     list *plist = get_paths(valid_list);
     int scales[] = {224, 288, 320, 352, 384};
     int nscales = sizeof(scales)/sizeof(scales[0]);
@@ -584,7 +584,7 @@ void try_classifier(char *datacfg, char *cfgfile, char *weightfile, char *filena
     int top = option_find_int(options, "top", 1);
 
     int i = 0;
-    char **names = get_labels(name_list);
+    char **names = get_labels(name_list, NULL);
     clock_t time;
     int *indexes = calloc(top, sizeof(int));
     char buff[256];
@@ -665,7 +665,7 @@ void predict_classifier(char *datacfg, char *cfgfile, char *weightfile, char *fi
     if(top == 0) top = option_find_int(options, "top", 1);
 
     int i = 0;
-    char **names = get_labels(name_list);
+    char **names = get_labels(name_list,NULL);
     clock_t time;
     int *indexes = calloc(top, sizeof(int));
     char buff[256];
@@ -720,7 +720,7 @@ void label_classifier(char *datacfg, char *filename, char *weightfile)
     char *test_list = option_find_str(options, "test", "data/train.list");
     int classes = option_find_int(options, "classes", 2);
 
-    char **labels = get_labels(label_list);
+    char **labels = get_labels(label_list, NULL);
     list *plist = get_paths(test_list);
 
     char **paths = (char **)list_to_array(plist);
@@ -842,7 +842,7 @@ void threat_classifier(char *datacfg, char *cfgfile, char *weightfile, int cam_i
     int top = option_find_int(options, "top", 1);
 
     char *name_list = option_find_str(options, "names", 0);
-    char **names = get_labels(name_list);
+    char **names = get_labels(name_list, NULL);
 
     int *indexes = calloc(top, sizeof(int));
 
@@ -974,7 +974,7 @@ void gun_classifier(char *datacfg, char *cfgfile, char *weightfile, int cam_inde
     int top = option_find_int(options, "top", 1);
 
     char *name_list = option_find_str(options, "names", 0);
-    char **names = get_labels(name_list);
+    char **names = get_labels(name_list, NULL);
 
     int *indexes = calloc(top, sizeof(int));
 
@@ -1051,7 +1051,7 @@ void demo_classifier(char *datacfg, char *cfgfile, char *weightfile, int cam_ind
     int top = option_find_int(options, "top", 1);
 
     char *name_list = option_find_str(options, "names", 0);
-    char **names = get_labels(name_list);
+    char **names = get_labels(name_list,NULL);
 
     int *indexes = calloc(top, sizeof(int));
 

--- a/examples/coco.c
+++ b/examples/coco.c
@@ -342,7 +342,7 @@ void test_coco(char *cfgfile, char *weightfile, char *filename, float thresh)
         printf("%s: Predicted in %f seconds.\n", input, sec(clock()-time));
         get_detection_boxes(l, 1, 1, thresh, probs, boxes, 0);
         if (nms) do_nms_sort(boxes, probs, l.side*l.side*l.n, l.classes, nms);
-        draw_detections(im, l.side*l.side*l.n, thresh, boxes, probs, 0, coco_classes, alphabet, 80);
+        draw_detections(im, l.side*l.side*l.n, thresh, boxes, probs, 0, coco_classes, sizeof(coco_classes)/sizeof(coco_classes[0]), alphabet, 80);
         save_image(im, "prediction");
         show_image(im, "predictions");
         free_image(im);

--- a/examples/detector.c
+++ b/examples/detector.c
@@ -234,7 +234,7 @@ void validate_detector_flip(char *datacfg, char *cfgfile, char *weightfile, char
     char *valid_images = option_find_str(options, "valid", "data/train.list");
     char *name_list = option_find_str(options, "names", "data/names.list");
     char *prefix = option_find_str(options, "results", "results");
-    char **names = get_labels(name_list);
+    char **names = get_labels(name_list, NULL);
     char *mapf = option_find_str(options, "map", 0);
     int *map = 0;
     if (mapf) map = read_map(mapf);
@@ -370,7 +370,7 @@ void validate_detector(char *datacfg, char *cfgfile, char *weightfile, char *out
     char *valid_images = option_find_str(options, "valid", "data/train.list");
     char *name_list = option_find_str(options, "names", "data/names.list");
     char *prefix = option_find_str(options, "results", "results");
-    char **names = get_labels(name_list);
+    char **names = get_labels(name_list, NULL);
     char *mapf = option_find_str(options, "map", 0);
     int *map = 0;
     if (mapf) map = read_map(mapf);
@@ -575,8 +575,9 @@ void test_detector(char *datacfg, char *cfgfile, char *weightfile, char *filenam
 {
     list *options = read_data_cfg(datacfg);
     char *name_list = option_find_str(options, "names", "data/names.list");
-    char **names = get_labels(name_list);
-
+    int names_count = 0;
+    char **names = get_labels(name_list, &names_count);
+    
     image **alphabet = load_alphabet();
     network net = parse_network_cfg(cfgfile);
     if(weightfile){
@@ -623,7 +624,7 @@ void test_detector(char *datacfg, char *cfgfile, char *weightfile, char *filenam
         get_region_boxes(l, im.w, im.h, net.w, net.h, thresh, probs, boxes, masks, 0, 0, hier_thresh, 1);
         if (nms) do_nms_obj(boxes, probs, l.w*l.h*l.n, l.classes, nms);
         //else if (nms) do_nms_sort(boxes, probs, l.w*l.h*l.n, l.classes, nms);
-        draw_detections(im, l.w*l.h*l.n, thresh, boxes, probs, masks, names, alphabet, l.classes);
+        draw_detections(im, l.w*l.h*l.n, thresh, boxes, probs, masks, names, names_count, alphabet, l.classes);
         if(outfile){
             save_image(im, outfile);
         }
@@ -703,7 +704,7 @@ void run_detector(int argc, char **argv)
         list *options = read_data_cfg(datacfg);
         int classes = option_find_int(options, "classes", 20);
         char *name_list = option_find_str(options, "names", "data/names.list");
-        char **names = get_labels(name_list);
+        char **names = get_labels(name_list, NULL);
         demo(cfg, weights, thresh, cam_index, filename, names, classes, frame_skip, prefix, avg, hier_thresh, width, height, fps, fullscreen);
     }
 }

--- a/examples/tag.c
+++ b/examples/tag.c
@@ -93,7 +93,7 @@ void test_tag(char *cfgfile, char *weightfile, char *filename)
     set_batch_network(&net, 1);
     srand(2222222);
     int i = 0;
-    char **names = get_labels("data/tags.txt");
+    char **names = get_labels("data/tags.txt", NULL);
     clock_t time;
     int indexes[10];
     char buff[256];

--- a/examples/yolo.c
+++ b/examples/yolo.c
@@ -308,7 +308,7 @@ void test_yolo(char *cfgfile, char *weightfile, char *filename, float thresh)
         printf("%s: Predicted in %f seconds.\n", input, sec(clock()-time));
         get_detection_boxes(l, 1, 1, thresh, probs, boxes, 0);
         if (nms) do_nms_sort(boxes, probs, l.side*l.side*l.n, l.classes, nms);
-        draw_detections(im, l.side*l.side*l.n, thresh, boxes, probs, 0, voc_names, alphabet, 20);
+        draw_detections(im, l.side*l.side*l.n, thresh, boxes, probs, 0, voc_names, sizeof(voc_names) / sizeof(voc_names[0]), alphabet, 20);
         save_image(im, "predictions");
         show_image(im, "predictions");
 

--- a/include/darknet.h
+++ b/include/darknet.h
@@ -688,7 +688,7 @@ void do_nms(box *boxes, float **probs, int total, int classes, float thresh);
 data load_all_cifar10();
 box_label *read_boxes(char *filename, int *n);
 box float_to_box(float *f, int stride);
-void draw_detections(image im, int num, float thresh, box *boxes, float **probs, float **masks, char **names, image **alphabet, int classes);
+void draw_detections(image im, int num, float thresh, box *boxes, float **probs, float **masks, char **names, int names_count, image **alphabet, int classes);
 
 matrix network_predict_data(network net, data test);
 image **load_alphabet();
@@ -706,7 +706,7 @@ box *make_boxes(network *net);
 void reset_network_state(network net, int b);
 void reset_network_state(network net, int b);
 
-char **get_labels(char *filename);
+char **get_labels(char *filename, int *labels_count);
 void do_nms_sort(box *boxes, float **probs, int total, int classes, float thresh);
 void do_nms_obj(box *boxes, float **probs, int total, int classes, float thresh);
 

--- a/src/data.c
+++ b/src/data.c
@@ -598,9 +598,12 @@ matrix load_tags_paths(char **paths, int n, int k)
     return y;
 }
 
-char **get_labels(char *filename)
+char **get_labels(char *filename, int *labels_count)
 {
     list *plist = get_paths(filename);
+    if(labels_count) {
+        *labels_count = plist->size;
+    }
     char **labels = (char **)list_to_array(plist);
     free_list(plist);
     return labels;

--- a/src/image.c
+++ b/src/image.c
@@ -190,7 +190,7 @@ image **load_alphabet()
     return alphabets;
 }
 
-void draw_detections(image im, int num, float thresh, box *boxes, float **probs, float **masks, char **names, image **alphabet, int classes)
+void draw_detections(image im, int num, float thresh, box *boxes, float **probs, float **masks, char **names, int names_count, image **alphabet, int classes)
 {
     int i;
 
@@ -206,7 +206,11 @@ void draw_detections(image im, int num, float thresh, box *boxes, float **probs,
             }
 
             //printf("%d %s: %.0f%%\n", i, names[class], prob*100);
-            printf("%s: %.0f%%\n", names[class], prob*100);
+            if(class < names_count) {
+                printf("%s: %.0f%%\n", names[class], prob*100);
+            } else {
+                printf("class-%d: %.0f%%\n", class, prob*100);
+            }
             int offset = class*123457 % classes;
             float red = get_color(2,offset,classes);
             float green = get_color(1,offset,classes);
@@ -232,7 +236,14 @@ void draw_detections(image im, int num, float thresh, box *boxes, float **probs,
 
             draw_box_width(im, left, top, right, bot, width, red, green, blue);
             if (alphabet) {
-                image label = get_label(alphabet, names[class], (im.h*.03)/10);
+                image label;
+                if(class < names_count) {
+                    label =  get_label(alphabet, names[class], (im.h*.03)/10);
+                } else {
+                    char tempname[40];
+                    sprintf(tempname, "class-%d", class);
+                    label =  get_label(alphabet, tempname, (im.h*.03)/10);
+                }
                 draw_label(im, top + width, left, label, rgb);
                 free_image(label);
             }

--- a/src/option_list.c
+++ b/src/option_list.c
@@ -42,7 +42,7 @@ metadata get_metadata(char *file)
     if(!name_list) {
         fprintf(stderr, "No names or labels found\n");
     } else {
-        m.names = get_labels(name_list);
+        m.names = get_labels(name_list, NULL);
     }
     m.classes = option_find_int(options, "classes", 2);
     free_list(options);

--- a/src/tree.c
+++ b/src/tree.c
@@ -72,7 +72,12 @@ int hierarchy_top_prediction(float *predictions, tree *hier, float thresh, int s
             group = hier->child[max_i];
             if(hier->child[max_i] < 0) return max_i;
         } else {
-            return hier->parent[hier->group_offset[group]];
+            int result = hier->parent[hier->group_offset[group]];
+            if(result != -1) {
+                return result;
+            } else {
+                break;
+            }
         }
     }
     return 0;


### PR DESCRIPTION
Prevent buffer overflows when there isn't enough names provided for the given model.

This fixes issue #149 – Tested on macOS 10.12.6 with Xcode 9 GM.
