### PR TITLE
Added extern "C" to allow cplusplus compilation

### DIFF
--- a/include/darknet.h
+++ b/include/darknet.h
@@ -31,6 +31,10 @@ extern int gpu_index;
     #endif
 #endif
 
+#ifdef __cplusplus
+    extern "C"{
+#endif
+
 typedef struct{
     int classes;
     char **names;
@@ -750,5 +754,9 @@ void normalize_array(float *a, int n);
 int *read_intlist(char *s, int *n, int d);
 size_t rand_size_t();
 float rand_normal();
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
I tried to use compiled libdarknet in a c++ application with definitions -DGPU=1 and -DOPENCV=1. During linking stage, several undefined reference appeared.
This patch adds extern "C" scope when __cplusplus is defined fixing the undefined reference issue.