### PR TITLE
fix #227 softmax parts of the code wasn't being run when GPU=1

### DIFF
--- a/src/region_layer.c
+++ b/src/region_layer.c
@@ -156,7 +156,6 @@ void forward_region_layer(const layer l, network net)
     int i,j,b,t,n;
     memcpy(l.output, net.input, l.outputs*l.batch*sizeof(float));
 
-#ifndef GPU
     for (b = 0; b < l.batch; ++b){
         for(n = 0; n < l.n; ++n){
             int index = entry_index(l, b, n*l.w*l.h, 0);
@@ -177,7 +176,6 @@ void forward_region_layer(const layer l, network net)
         int index = entry_index(l, 0, 0, l.coords + !l.background);
         softmax_cpu(net.input + index, l.classes + l.background, l.batch*l.n, l.inputs/l.n, l.w*l.h, 1, l.w*l.h, 1, l.output + index);
     }
-#endif
 
     memset(l.delta, 0, l.outputs * l.batch * sizeof(float));
     if(!net.train) return;


### PR DESCRIPTION
Investigating we found that parts in forward_region_layer function was not reachable when GPU was set to 1.

I believe this #ifndef GPU is not necessary because this function is not called in case of GPU anyway. Am I wrong?