### PR TITLE
Fix CUDA includes when including darknet.h from *.cpp file

### DIFF
--- a/include/darknet.h
+++ b/include/darknet.h
@@ -11,6 +11,7 @@ extern int gpu_index;
 #ifdef GPU
     #define BLOCK 512
 
+#ifndef __cplusplus
     #include "cuda_runtime.h"
     #include "curand.h"
     #include "cublas_v2.h"
@@ -18,6 +19,8 @@ extern int gpu_index;
     #ifdef CUDNN
     #include "cudnn.h"
     #endif
+#endif
+
 #endif
 
 #ifndef __cplusplus


### PR DESCRIPTION
When integrating prebuilt darknet framework into cpp project you have to include `darknet.h` as 

```
extern "C" {
#include <darknet.h>
}
```

With `-DGPU=1` you will get compilation errors like

```
/usr/local/cuda/include/cuda_runtime.h:528:1: error: template with C linkage
 template<class T>
```

cause `cuda_runtime.h` etc has cpp code inside