### PR TITLE
coordinate calculation fixed in place_image(). dtype int -> float

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -749,8 +749,8 @@ void place_image(image im, int w, int h, int dx, int dy, image canvas)
     for(c = 0; c < im.c; ++c){
         for(y = 0; y < h; ++y){
             for(x = 0; x < w; ++x){
-                int rx = ((float)x / w) * im.w;
-                int ry = ((float)y / h) * im.h;
+                float rx = ((float)x / w) * im.w;
+                float ry = ((float)y / h) * im.h;
                 float val = bilinear_interpolate(im, rx, ry, c);
                 set_pixel(canvas, x + dx, y + dy, c, val);
             }


### PR DESCRIPTION
the coordinate to copy pixel value is declared as int type in place_image. Changed it to float type because bilinear interpolation will not work correctly with int types.