### PR TITLE
set CUDA library search path for Mac OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ ALIB=libdarknet.a
 EXEC=darknet
 OBJDIR=./obj/
 
+OS=$(shell uname -s)
 CC=gcc
 NVCC=nvcc 
 AR=ar
@@ -48,7 +49,12 @@ endif
 ifeq ($(GPU), 1) 
 COMMON+= -DGPU -I/usr/local/cuda/include/
 CFLAGS+= -DGPU
-LDFLAGS+= -L/usr/local/cuda/lib64 -lcuda -lcudart -lcublas -lcurand
+ifeq ($(OS), Darwin)
+LDFLAGS+= -L/usr/local/cuda/lib
+else
+LDFLAGS+= -L/usr/local/cuda/lib64
+endif
+LDFLAGS+=-lcuda -lcudart -lcublas -lcurand
 endif
 
 ifeq ($(CUDNN), 1) 


### PR DESCRIPTION
darknet failed to build on Mac OS X, because the Makefile passed an incorrect
library search path for locating CUDA libraries.
On Mac OS X, CUDA library installation path is /usr/local/cuda/lib by default.
This patch fixed the issue.