### PR TITLE
cfg read error fixed. "First section must be [net] or [network]"

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -778,6 +778,7 @@ list *read_cfg(char *filename)
     while((line=fgetl(file)) != 0){
         ++ nu;
         strip(line);
+        line[ strcspn(line, "\r\n") ]  = '\0'; 
         switch(line[0]){
             case '[':
                 current = malloc(sizeof(section));


### PR DESCRIPTION
Many users have problems while parsing cfg file when it is copied from other systems due to newline character.