### PR TITLE
FIX bounding box not showing up in predictions.png

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -255,7 +255,7 @@ void draw_detections(image im, int num, float thresh, box *boxes, float **probs,
             }
         }
         if(class >= 0){
-            int width = im.h * .006;
+            int width = fmax(1, im.h * .006);
 
             /*
                if(0){


### PR DESCRIPTION
If the image size is small (in my case 96px), bounding boxes won't render because `im.h * .006` is < 0, therefore loop in `draw_box_width` won't activate