### PR TITLE
fix make_dropout_layer

### DIFF
--- a/src/dropout_layer.c
+++ b/src/dropout_layer.c
@@ -27,7 +27,7 @@ dropout_layer make_dropout_layer(int batch, int inputs, float probability)
 
 void resize_dropout_layer(dropout_layer *l, int inputs)
 {
-    l->rand = realloc(l->rand, l->inputs*l->batch*sizeof(float));
+    l->rand = realloc(l->rand, inputs*l->batch*sizeof(float));
     #ifdef GPU
     cuda_free(l->rand_gpu);
 


### PR DESCRIPTION
If you want to resize dropout layer, you may want to realloc inputs*l->batch*sizeof(float).