### PR TITLE
cudnnBatchNormalizationForwardInference usage

### DIFF
--- a/src/batchnorm_layer.c
+++ b/src/batchnorm_layer.c
@@ -228,9 +228,29 @@ void forward_batchnorm_layer_gpu(layer l, network net)
         add_bias_gpu(l.output_gpu, l.biases_gpu, l.batch, l.out_c, l.out_w*l.out_h);
 #endif
     } else {
+#ifdef CUDNN
+        float one = 1;
+        float zero = 0;
+        cudnnBatchNormalizationForwardInference(cudnn_handle(),
+            CUDNN_BATCHNORM_SPATIAL,
+            &one,
+            &zero,
+            l.dstTensorDesc,
+            l.x_gpu,
+            l.dstTensorDesc,
+            l.output_gpu,
+            l.normTensorDesc,
+            l.scales_gpu,
+            l.biases_gpu,
+            l.rolling_mean_gpu,
+            l.rolling_variance_gpu,
+            .00001);
+
+#else
         normalize_gpu(l.output_gpu, l.rolling_mean_gpu, l.rolling_variance_gpu, l.batch, l.out_c, l.out_h*l.out_w);
         scale_bias_gpu(l.output_gpu, l.scales_gpu, l.batch, l.out_c, l.out_h*l.out_w);
         add_bias_gpu(l.output_gpu, l.biases_gpu, l.batch, l.out_c, l.out_w*l.out_h);
+#endif
     }
 
 }


### PR DESCRIPTION
Is there a reason why Yolo is not using CUDNN for batchnorm ?

On profiling, almost 23% of GPU kernel time is spent on add_bias_gpu CUDA kernel. Using CUDNN, the detection time reduces about 19%. In v3 there are 74 convolutional elements with batchnorm. 

Validated with CUDA8, and with standard yolov3 detector cfg, with the pretrained weights  yolov3.weights, and with the dog/bird/person images for inference.