### PR TITLE
Add functions to load image from memory.

### DIFF
--- a/include/darknet.h
+++ b/include/darknet.h
@@ -258,7 +258,7 @@ struct layer{
 
     float * m;
     float * v;
-    
+
     float * bias_m;
     float * bias_v;
     float * scale_m;
@@ -283,7 +283,7 @@ struct layer{
     float *g_cpu;
     float *o_cpu;
     float *c_cpu;
-    float *dc_cpu; 
+    float *dc_cpu;
 
     float * binary_input;
 
@@ -310,7 +310,7 @@ struct layer{
 
     struct layer *input_h_layer;
     struct layer *state_h_layer;
-	
+
     struct layer *wz;
     struct layer *uz;
     struct layer *wr;
@@ -350,7 +350,7 @@ struct layer{
     float *g_gpu;
     float *o_gpu;
     float *c_gpu;
-    float *dc_gpu; 
+    float *dc_gpu;
 
     float *m_gpu;
     float *v_gpu;
@@ -690,7 +690,9 @@ void free_network(network *net);
 void set_batch_network(network *net, int b);
 void set_temp_network(network *net, float t);
 image load_image(char *filename, int w, int h, int c);
+image load_image_from_memory(unsigned char *buf, int len, int w, int h, int c);
 image load_image_color(char *filename, int w, int h);
+image load_image_from_memory_color(unsigned char *buf, int len, int w, int h);
 image make_image(int w, int h, int c);
 image resize_image(image im, int w, int h);
 void censor_image(image im, int dx, int dy, int w, int h);


### PR DESCRIPTION
Hi @pjreddie !

First and foremost, thanks for the great work! :relaxed: 

I would like to suggest the addition of image-loading functions that can read image data directly from memory, besides the existing ones that read from filename.

For some use cases out there at-large, it would be great to skip the hard disk, if the source image file data already exists in memory.

This pull request contains an implementation of such functions. Both OpenCV and stb versions of the functions are implemented.

I have a branch on my own fork, named [load-image-from-memory-in-action], which shows the implementation in action.

I look forward to your favourable response to merging this pull request.

[load-image-from-memory-in-action]: https://github.com/gyonluks/darknet/tree/load-image-from-memory-in-action

P.S: The code editor I use removes trailing whitespaces, so please don't mind those whitespace-only changes. :sweat_smile: 