### PR TITLE
Fix Security Vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ Darknet is an open source neural network framework written in C and CUDA. It is 
 For more information see the [Darknet project website](http://pjreddie.com/darknet).
 
 For questions or issues please use the [Google Group](https://groups.google.com/forum/#!forum/darknet).
+
+Darknet has not been tested for security vulnerabilities, and could be vulnerable to attacks. Consider the risks before deploying in a production environment.

--- a/src/image.c
+++ b/src/image.c
@@ -631,7 +631,6 @@ image load_image_cv(char *filename, int channels)
     if( (src = cvLoadImage(filename, flag)) == 0 )
     {
         fprintf(stderr, "Cannot load image \"%s\"\n", filename);
-        char buff[1024];
         char truncated_buffer[1024];
         
         // Check the length of the buffer
@@ -645,7 +644,7 @@ image load_image_cv(char *filename, int channels)
         // Write directly to the file rather than using the system call to write
         FILE* bad_list = fopen("bad.list", "a");
         fwrite(truncated_buffer, sizeof(char), strlen(truncated_buffer), bad_list);
-        fwrite("\n", 1, 1, truncated_buffer);
+        fwrite("\n", 1, 1, bad_list);
 
         return make_image(10,10,3);
     }

--- a/src/image.c
+++ b/src/image.c
@@ -631,11 +631,23 @@ image load_image_cv(char *filename, int channels)
     if( (src = cvLoadImage(filename, flag)) == 0 )
     {
         fprintf(stderr, "Cannot load image \"%s\"\n", filename);
-        char buff[256];
-        sprintf(buff, "echo %s >> bad.list", filename);
-        system(buff);
+        char buff[1024];
+        char truncated_buffer[1024];
+        
+        // Check the length of the buffer
+        if(strlen(filename) > 1024) {
+            sprintf(truncated_buffer, "This filename is too long");
+        }
+        else {
+            sprintf(truncated_buffer, "%s", filename);
+        }
+
+        // Write directly to the file rather than using the system call to write
+        FILE* bad_list = fopen("bad.list", "a");
+        fwrite(truncated_buffer, sizeof(char), strlen(truncated_buffer), bad_list);
+        fwrite("\n", 1, 1, truncated_buffer);
+
         return make_image(10,10,3);
-        //exit(0);
     }
     image out = ipl_to_image(src);
     cvReleaseImage(&src);


### PR DESCRIPTION
Although I have not conducted a thorough security test, there are a few important security vulnerabilities that could be making users vulnerable. Consider the following code in src/image.c: 

`fprintf(stderr,` "Cannot load image \"%s\"\n", filename);
char buff[256];
sprintf(buff, "echo %s >> bad.list", filename);
system(buff);
return make_image(10,10,3);`

This example actually contains two security vulnerabilities:
- Buffer Overflow
- Command Injection

Since the user controls the filename parameter, it can be of any length. A sufficiently large filename would overflow the 256 byte buffer, causing a buffer overflow. Without modern protections, malicious users could gain arbitrary execution through this vulnerability.

For command injection, since a call is made to system, and the filename is sprintf'd into the buffer, users can effectively make any calls they want to the system. For example, consider the following filename: "; ls; ls". When copied to the buffer, the following call is made:
`system("echo ; ls; ls >> bad.list");`
This would let users run any command they want with almost no effort and would work on all systems running this program. This one is particularly bad as any user exposing this filename parameter is immediately affected. I have fixed both issues in this PR.

These vulnerabilities are potentially very dangerous to anyone who runs Darknet as a service. Again, I've only briefly looked at Darknet from a security perspective, and there may be more problems. To that end, I also included a short sentence about security concerns in the README.

Thank you very much and I hope you take these edits into consideration soon as they are vital to Darknet's security.