### PR TITLE
Suggest small function addition

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -589,6 +589,22 @@ void show_image(image p, const char *name)
 
 #ifdef OPENCV
 
+void image_into_ipl(image p, IplImage *disp)
+{
+    int x,y,k;
+    if(p.c == 3) rgbgr_image(p);
+
+    int step = disp->widthStep;
+
+    for(y = 0; y < p.h; ++y){
+        for(x = 0; x < p.w; ++x){
+            for(k= 0; k < p.c; ++k){
+                disp->imageData[y*step + x*p.c + k] = (unsigned char)(get_pixel(p,x,y,k)*255);
+            }
+        }
+    }
+}
+
 void ipl_into_image(IplImage* src, image im)
 {
     unsigned char *data = (unsigned char *)src->imageData;


### PR DESCRIPTION
I am suggesting to add this function. It's basically the same as
void show_image_cv(image p, const char *name, IplImage *disp)

however darknet_ros calls that function, and as a result, cannot transport the image into the ROS message properly without also displaying the openCV image. If this request succeeds, I will also add a pull request for darknet_ros