### PR TITLE
Memory overallocation

### DIFF
--- a/examples/detector.c
+++ b/examples/detector.c
@@ -13,7 +13,7 @@ void train_detector(char *datacfg, char *cfgfile, char *weightfile, int *gpus, i
     char *base = basecfg(cfgfile);
     printf("%s\n", base);
     float avg_loss = -1;
-    network **nets = calloc(ngpus, sizeof(network));
+    network **nets = calloc(ngpus, sizeof(network*));
 
     srand(time(0));
     int seed = rand();

--- a/src/image.c
+++ b/src/image.c
@@ -224,7 +224,7 @@ image **load_alphabet()
 {
     int i, j;
     const int nsize = 8;
-    image **alphabets = calloc(nsize, sizeof(image));
+    image **alphabets = calloc(nsize, sizeof(image*));
     for(j = 0; j < nsize; ++j){
         alphabets[j] = calloc(128, sizeof(image));
         for(i = 32; i < 127; ++i){


### PR DESCRIPTION
This PR fixes two similar bugs. After finding the first one I grep'd for more examples and only found the one. In each case, an array of pointers is allocated using the size of the object, not the size of the pointer. Thankfully, this results in over-, not under-, allocation in each case, but it seems wise to fix these.