### PR TITLE
Fix model loading on ARMv7

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1218,7 +1218,9 @@ void load_weights_upto(network *net, char *filename, int start, int cutoff)
     fread(&minor, sizeof(int), 1, fp);
     fread(&revision, sizeof(int), 1, fp);
     if ((major*10 + minor) >= 2 && major < 1000 && minor < 1000){
-        fread(net->seen, sizeof(size_t), 1, fp);
+        unsigned long long iseen = 0;  // 64-bit on ILP32 and LP64.
+        fread(&iseen, sizeof(iseen), 1, fp);
+        *net->seen = (size_t) iseen;
     } else {
         int iseen = 0;
         fread(&iseen, sizeof(int), 1, fp);


### PR DESCRIPTION
size_t is 4 bytes on ARMv7 (32bit), but size_t is 8 bytes in x86_amd64 system.
Tested on Raspberry Pi 3.