### PR TITLE
Don't resize input image if it's already scaled to network size

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -578,10 +578,12 @@ void free_detections(detection *dets, int n)
 
 float *network_predict_image(network *net, image im)
 {
-    image imr = letterbox_image(im, net->w, net->h);
+    bool resize = im.w != net->w || im.h != net->h;
+    image imr = resize ? letterbox_image(im, net->w, net->h) : im;
     set_batch_network(net, 1);
     float *p = network_predict(net, imr.data);
-    free_image(imr);
+    if(resize)
+        free_image(imr);
     return p;
 }
 


### PR DESCRIPTION
Letterboxing is an expensive operation, so don't do it in `network_detect_image` when the input is already scaled to the network size.