### PR TITLE
Fix miss GT line in region_layer

### DIFF
--- a/src/region_layer.c
+++ b/src/region_layer.c
@@ -200,7 +200,7 @@ void forward_region_layer(const layer l, network net)
             int onlyclass = 0;
             for(t = 0; t < 30; ++t){
                 box truth = float_to_box(net.truth + t*(l.coords + 1) + b*l.truths, 1);
-                if(!truth.x) break;
+                if(!truth.x) continue;
                 int class = net.truth[t*(l.coords + 1) + b*l.truths + l.coords];
                 float maxp = 0;
                 int maxi = 0;
@@ -237,7 +237,7 @@ void forward_region_layer(const layer l, network net)
                     float best_iou = 0;
                     for(t = 0; t < 30; ++t){
                         box truth = float_to_box(net.truth + t*(l.coords + 1) + b*l.truths, 1);
-                        if(!truth.x) break;
+                        if(!truth.x) continue;
                         float iou = box_iou(pred, truth);
                         if (iou > best_iou) {
                             best_iou = iou;
@@ -265,7 +265,7 @@ void forward_region_layer(const layer l, network net)
         for(t = 0; t < 30; ++t){
             box truth = float_to_box(net.truth + t*(l.coords + 1) + b*l.truths, 1);
 
-            if(!truth.x) break;
+            if(!truth.x) continue;
             float best_iou = 0;
             int best_n = 0;
             i = (truth.x * l.w);


### PR DESCRIPTION
Change gt loop *break* to *continue*.
As we tested, some of the GT box will be change to 0 after the data augmentation. Thus, the following GT boxes will be ignored, if the x of this line is 0. The mAP validation of PASCAL VOC of this change will increase.

The following example of a miss GT (the third line is a miss GT line):
0.02 0.48 0.04 0.07 6
0.70 0.47 0.26 0.10 5
0.00 0.00 0.00 0.00 0
0.35 0.58 0.12 0.07 6
0.21 0.57 0.34 0.17 6
0.17 0.74 0.34 0.49 6
...