### PR TITLE
Fix syntax of print to allow use with Python3

### DIFF
--- a/python/darknet.py
+++ b/python/darknet.py
@@ -151,6 +151,6 @@ if __name__ == "__main__":
     net = load_net("cfg/tiny-yolo.cfg", "tiny-yolo.weights", 0)
     meta = load_meta("cfg/coco.data")
     r = detect(net, meta, "data/dog.jpg")
-    print r
+    print(r)
     
 


### PR DESCRIPTION
Update from `print r` to `print(r)` - this allows use with Python3