### PR TITLE
In rgb_to_hsv function, when delta==0, the value is -nan

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -976,7 +976,7 @@ void rgb_to_hsv(image im)
             float min = three_way_min(r,g,b);
             float delta = max - min;
             v = max;
-            if(max == 0){
+            if(max == 0 || delta < 0.00001){
                 s = 0;
                 h = 0;
             }else{


### PR DESCRIPTION
In `src/image.c/rgb_to_hsv` function, `h=(g-b)/delta`
when  `r=g=b`, it causes `delta == 0`
then `h == nan`.
Therefore, when the `delta<0.00001`, `s` and `v`  should be set to `0`.
  