### PR TITLE
Made changes that allow variables to set with env variables.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,67 +1,73 @@
-GPU=0
-CUDNN=0
-OPENCV=0
-OPENMP=0
-DEBUG=0
+GPU?=0
+CUDNN?=${GPU} # Assume if CUDA is installed so is CUDNN.
+OPENCV?=0
+OPENMP?=0
+DEBUG?=0
 
-ARCH= -gencode arch=compute_30,code=sm_30 \
-      -gencode arch=compute_35,code=sm_35 \
-      -gencode arch=compute_50,code=[sm_50,compute_50] \
-      -gencode arch=compute_52,code=[sm_52,compute_52]
-#      -gencode arch=compute_20,code=[sm_20,sm_21] \ This one is deprecated?
+# CUDA architectures
+# https://github.com/tpruvot/ccminer/wiki/Compatibility
 
-# This is what I use, uncomment if you know your arch and want to specify
-# ARCH= -gencode arch=compute_52,code=compute_52
+#ARCH:=-gencode=arch=compute_75,code=[sm_75,compute_75]
+#ARCH:=-gencode=arch=compute_70,code=[sm_70,compute_70]
+#ARCH:=-gencode=arch=compute_61,code=[sm_61,compute_61]
+#ARCH:=-gencode=arch=compute_60,code=[sm_60,compute_60]
+ARCH?=-gencode=arch=compute_52,code=[sm_52,compute_52]
+#ARCH:=-gencode=arch=compute_50,code=[sm_50,compute_50]
 
+# Ta
 VPATH=./src/:./examples
-SLIB=libdarknet.so
-ALIB=libdarknet.a
-EXEC=darknet
+EXEC?=darknet
+LIB_BASE?=lib${EXEC}
+SLIB?=${LIB_BASE}net.so
+ALIB?=${LIB_BASE}libdarknet.a
 OBJDIR=./obj/
 
-CC=gcc
-CPP=g++
-NVCC=nvcc 
-AR=ar
-ARFLAGS=rcs
-OPTS=-Ofast
-LDFLAGS= -lm -pthread 
-COMMON= -Iinclude/ -Isrc/
-CFLAGS=-Wall -Wno-unused-result -Wno-unknown-pragmas -Wfatal-errors -fPIC
+# Compiler
+CC?=gcc
+CPP?=g++
+NVCC?=nvcc
+AR?=ar
 
-ifeq ($(OPENMP), 1) 
+# Compiler Flags
+ARFLAGS=rcs
+OPTS+=-Ofast -mtune=skylake
+LDFLAGS+= -lm -pthread
+COMMON+= -Iinclude/ -Isrc/
+CFLAGS+= -Wall -Wno-unused-result -Wno-unknown-pragmas -Wfatal-errors -fPIC
+
+ifeq ($(OPENMP), 1)
 CFLAGS+= -fopenmp
 endif
 
-ifeq ($(DEBUG), 1) 
+ifeq ($(DEBUG), 1)
 OPTS=-O0 -g
 endif
 
 CFLAGS+=$(OPTS)
 
-ifeq ($(OPENCV), 1) 
+ifeq ($(OPENCV), 1)
 COMMON+= -DOPENCV
 CFLAGS+= -DOPENCV
-LDFLAGS+= `pkg-config --libs opencv` -lstdc++
-COMMON+= `pkg-config --cflags opencv` 
+LDFLAGS+= `pkg-config --libs opencv`
+COMMON+= `pkg-config --cflags opencv`
 endif
 
-ifeq ($(GPU), 1) 
+ifeq ($(GPU), 1)
 COMMON+= -DGPU -I/usr/local/cuda/include/
 CFLAGS+= -DGPU
-LDFLAGS+= -L/usr/local/cuda/lib64 -lcuda -lcudart -lcublas -lcurand
+LDFLAGS+= -L/usr/local/cuda/lib64 -lcudart -lcublas -lcurand
 endif
 
-ifeq ($(CUDNN), 1) 
-COMMON+= -DCUDNN 
+ifeq ($(CUDNN), 1)
+COMMON+= -DCUDNN
 CFLAGS+= -DCUDNN
 LDFLAGS+= -lcudnn
 endif
 
 OBJ=gemm.o utils.o cuda.o deconvolutional_layer.o convolutional_layer.o list.o image.o activations.o im2col.o col2im.o blas.o crop_layer.o dropout_layer.o maxpool_layer.o softmax_layer.o data.o matrix.o network.o connected_layer.o cost_layer.o parser.o option_list.o detection_layer.o route_layer.o upsample_layer.o box.o normalization_layer.o avgpool_layer.o layer.o local_layer.o shortcut_layer.o logistic_layer.o activation_layer.o rnn_layer.o gru_layer.o crnn_layer.o demo.o batchnorm_layer.o region_layer.o reorg_layer.o tree.o  lstm_layer.o l2norm_layer.o yolo_layer.o iseg_layer.o image_opencv.o
 EXECOBJA=captcha.o lsd.o super.o art.o tag.o cifar.o go.o rnn.o segmenter.o regressor.o classifier.o coco.o yolo.o detector.o nightmare.o instance-segmenter.o darknet.o
-ifeq ($(GPU), 1) 
-LDFLAGS+= -lstdc++ 
+ifeq ($(GPU), 1)
+LDFLAGS+= -lstdc++
 OBJ+=convolutional_kernels.o deconvolutional_kernels.o activation_kernels.o im2col_kernels.o col2im_kernels.o blas_kernels.o crop_layer_kernels.o dropout_layer_kernels.o maxpool_layer_kernels.o avgpool_layer_kernels.o
 endif
 
@@ -70,8 +76,6 @@ OBJS = $(addprefix $(OBJDIR), $(OBJ))
 DEPS = $(wildcard src/*.h) Makefile include/darknet.h
 
 all: obj backup results $(SLIB) $(ALIB) $(EXEC)
-#all: obj  results $(SLIB) $(ALIB) $(EXEC)
-
 
 $(EXEC): $(EXECOBJ) $(ALIB)
 	$(CC) $(COMMON) $(CFLAGS) $^ -o $@ $(LDFLAGS) $(ALIB)
@@ -99,7 +103,5 @@ results:
 	mkdir -p results
 
 .PHONY: clean
-
 clean:
 	rm -rf $(OBJS) $(SLIB) $(ALIB) $(EXEC) $(EXECOBJ) $(OBJDIR)/*
-

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ ARCH?=-gencode=arch=compute_52,code=[sm_52,compute_52]
 VPATH=./src/:./examples
 EXEC?=darknet
 LIB_BASE?=lib${EXEC}
-SLIB?=${LIB_BASE}net.so
-ALIB?=${LIB_BASE}libdarknet.a
+SLIB?=${LIB_BASE}.so
+ALIB?=${LIB_BASE}.a
 OBJDIR=./obj/
 
 # Compiler

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ AR?=ar
 
 # Compiler Flags
 ARFLAGS=rcs
-OPTS+=-Ofast -mtune=skylake
+OPTS+=-Ofast
 LDFLAGS+= -lm -pthread
 COMMON+= -Iinclude/ -Isrc/
 CFLAGS+= -Wall -Wno-unused-result -Wno-unknown-pragmas -Wfatal-errors -fPIC


### PR DESCRIPTION
Made changes that allow variables to set with env variables and not just when make is invoked. Relevant gnumake documentation: https://www.gnu.org/software/make/manual/html_node/Setting.html#Setting


Allows you to do stupid things like this: https://github.com/jed-frey/all_the_things/blob/master/build_darknet.sh

Also lets [pydarknet2](https://github.com/jed-frey/pydarknet2) build & compile by setting env variables.

- Also set CUDNN to the same value as GPU, because if you're going to go through the trouble why not go all the way.
- Added more GPU architectures (6.0, 6.1, 7.0, 7.5) and [documentation where to look up](https://github.com/tpruvot/ccminer/wiki/Compatibility) which one to use.
- Made the exec, libbase, slib and alib names sort roll up so you can set one and the others automagically change.
- Stripped trailing white spaces.
- Removed ```-lcuda``` because Nvidia deprecated it?