### PR TITLE
Fix compilation with latest OpenCV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ CFLAGS+=$(OPTS)
 ifeq ($(OPENCV), 1) 
 COMMON+= -DOPENCV
 CFLAGS+= -DOPENCV
-LDFLAGS+= `pkg-config --libs opencv` -lstdc++
-COMMON+= `pkg-config --cflags opencv` 
+LDFLAGS+= `pkg-config --libs opencv 2> /dev/null || pkg-config --libs opencv4` -lstdc++
+COMMON+= `pkg-config --cflags opencv 2> /dev/null || pkg-config --cflags opencv4`
 endif
 
 ifeq ($(GPU), 1) 

--- a/src/image_opencv.cpp
+++ b/src/image_opencv.cpp
@@ -9,30 +9,36 @@ using namespace cv;
 
 extern "C" {
 
-IplImage *image_to_ipl(image im)
+Mat image_to_mat(image im)
 {
+    assert(im.c == 3 || im.c == 1);
     int x,y,c;
-    IplImage *disp = cvCreateImage(cvSize(im.w,im.h), IPL_DEPTH_8U, im.c);
-    int step = disp->widthStep;
+    image copy = copy_image(im);
+    constrain_image(copy);
+    if(im.c == 3) rgbgr_image(copy);
+    unsigned char *data = (unsigned char *)malloc(im.w * im.h * im.c);
     for(y = 0; y < im.h; ++y){
         for(x = 0; x < im.w; ++x){
             for(c= 0; c < im.c; ++c){
-                float val = im.data[c*im.h*im.w + y*im.w + x];
-                disp->imageData[y*step + x*im.c + c] = (unsigned char)(val*255);
+                float val = copy.data[c*im.h*im.w + y*im.w + x];
+                data[y*im.w*im.c + x*im.c + c] = (unsigned char)(val*255);
             }
         }
     }
-    return disp;
+    Mat m(im.h, im.w, CV_MAKETYPE(CV_8U, im.c), data);
+    free_image(copy);
+    free(data);
+    return m;
 }
 
-image ipl_to_image(IplImage* src)
+image mat_to_image(Mat m)
 {
-    int h = src->height;
-    int w = src->width;
-    int c = src->nChannels;
+    int h = m.rows;
+    int w = m.cols;
+    int c = m.channels();
     image im = make_image(w, h, c);
-    unsigned char *data = (unsigned char *)src->imageData;
-    int step = src->widthStep;
+    unsigned char *data = (unsigned char*)m.data;
+    int step = m.step;
     int i, j, k;
 
     for(i = 0; i < h; ++i){
@@ -42,26 +48,6 @@ image ipl_to_image(IplImage* src)
             }
         }
     }
-    return im;
-}
-
-Mat image_to_mat(image im)
-{
-    image copy = copy_image(im);
-    constrain_image(copy);
-    if(im.c == 3) rgbgr_image(copy);
-
-    IplImage *ipl = image_to_ipl(copy);
-    Mat m = cvarrToMat(ipl, true);
-    cvReleaseImage(&ipl);
-    free_image(copy);
-    return m;
-}
-
-image mat_to_image(Mat m)
-{
-    IplImage ipl = m;
-    image im = ipl_to_image(&ipl);
     rgbgr_image(im);
     return im;
 }
@@ -72,9 +58,9 @@ void *open_video_stream(const char *f, int c, int w, int h, int fps)
     if(f) cap = new VideoCapture(f);
     else cap = new VideoCapture(c);
     if(!cap->isOpened()) return 0;
-    if(w) cap->set(CV_CAP_PROP_FRAME_WIDTH, w);
-    if(h) cap->set(CV_CAP_PROP_FRAME_HEIGHT, w);
-    if(fps) cap->set(CV_CAP_PROP_FPS, w);
+    if(w) cap->set(CAP_PROP_FRAME_WIDTH, w);
+    if(h) cap->set(CAP_PROP_FRAME_HEIGHT, w);
+    if(fps) cap->set(CAP_PROP_FPS, w);
     return (void *) cap;
 }
 
@@ -123,7 +109,7 @@ void make_window(char *name, int w, int h, int fullscreen)
 {
     namedWindow(name, WINDOW_NORMAL); 
     if (fullscreen) {
-        setWindowProperty(name, CV_WND_PROP_FULLSCREEN, CV_WINDOW_FULLSCREEN);
+        setWindowProperty(name, WND_PROP_FULLSCREEN, WINDOW_FULLSCREEN);
     } else {
         resizeWindow(name, w, h);
         if(strcmp(name, "Demo") == 0) moveWindow(name, 0, 0);


### PR DESCRIPTION
Fix #1347.

Some deprecated C APIs were removed from OpenCV 4 and must be replaced with C++ calls. This fix was tested on OpenCV `3.4.3` and `4.0.1`; it didn't regress the older build.

All C API calls using `IplImage` were replaced with equivalents using `cv::Mat`. Global constants starting with `CV_` were replaced with constants in the `cv::` namespace.

I didn't touch the examples. `examples/rnn_vid.c` could also be changed to support OpenCV 4.