### PR TITLE
GAP makes correspondance between feature maps and categories

### DIFF
--- a/cfg/darknet53.cfg
+++ b/cfg/darknet53.cfg
@@ -552,16 +552,14 @@ activation=leaky
 from=-3
 activation=linear
 
-#######################
-
-[avgpool]
-
 [convolutional]
 filters=1000
 size=1
 stride=1
 pad=1
 activation=linear
+
+[avgpool]
 
 [softmax]
 groups=1

--- a/cfg/darknet53.cfg
+++ b/cfg/darknet53.cfg
@@ -552,6 +552,8 @@ activation=leaky
 from=-3
 activation=linear
 
+#######################
+
 [avgpool]
 
 [convolutional]

--- a/src/parser.c
+++ b/src/parser.c
@@ -313,6 +313,8 @@ layer parse_yolo(list *options, size_params params)
     int *mask = parse_yolo_mask(a, &num);           // mask is the same as the `mask` in cfg that indicates the available anchors,
                                                     // num is the number of the mask.
     layer l = make_yolo_layer(params.batch, params.w, params.h, num, total, mask, classes);
+                                                    // params.{w, h} is the spatial shape of the yolo layer (i.e. grids shape),
+                                                    // params.batch is applied to the whole network.
     assert(l.outputs == params.inputs);
 
     l.max_boxes = option_find_int_quiet(options, "max",90);

--- a/src/parser.c
+++ b/src/parser.c
@@ -306,11 +306,12 @@ int *parse_yolo_mask(char *a, int *num)
 layer parse_yolo(list *options, size_params params)
 {
     int classes = option_find_int(options, "classes", 20);
-    int total = option_find_int(options, "num", 1);
+    int total = option_find_int(options, "num", 1); // total is the number of the whole anchors.
     int num = total;
 
     char *a = option_find_str(options, "mask", 0);
-    int *mask = parse_yolo_mask(a, &num);
+    int *mask = parse_yolo_mask(a, &num);           // mask is the same as the `mask` in cfg that indicates the available anchors,
+                                                    // num is the number of the mask.
     layer l = make_yolo_layer(params.batch, params.w, params.h, num, total, mask, classes);
     assert(l.outputs == params.inputs);
 


### PR DESCRIPTION
According to the paper 《Network in Network》, Global Average Pooling has the following benefits:
  1. generates one feature map for each corresponding category of the classification task
  2. easily interpreted
  3. reduce parameters

Only consider the first two reasons, what the paper did is `take the average of each feature map, and the resulting vector is fed
``directly`` into the softmax layer` (extracted from the paper) .
All I'm concerned is the word ``directly``, maybe use convolutional of 1000 filters before global average pooling would be better?
Sincerely Yours