### PR TITLE
Adding options to load images from a dataset and save predictions to CSV file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ CFLAGS+= -DCUDNN
 LDFLAGS+= -lcudnn
 endif
 
-OBJ=gemm.o utils.o cuda.o deconvolutional_layer.o convolutional_layer.o list.o image.o activations.o im2col.o col2im.o blas.o crop_layer.o dropout_layer.o maxpool_layer.o softmax_layer.o data.o matrix.o network.o connected_layer.o cost_layer.o parser.o option_list.o detection_layer.o route_layer.o upsample_layer.o box.o normalization_layer.o avgpool_layer.o layer.o local_layer.o shortcut_layer.o logistic_layer.o activation_layer.o rnn_layer.o gru_layer.o crnn_layer.o demo.o batchnorm_layer.o region_layer.o reorg_layer.o tree.o  lstm_layer.o l2norm_layer.o yolo_layer.o iseg_layer.o image_opencv.o
+OBJ=gemm.o utils.o cuda.o deconvolutional_layer.o convolutional_layer.o list.o image.o activations.o im2col.o col2im.o blas.o crop_layer.o dropout_layer.o maxpool_layer.o softmax_layer.o data.o matrix.o network.o connected_layer.o cost_layer.o parser.o option_list.o detection_layer.o route_layer.o upsample_layer.o box.o normalization_layer.o avgpool_layer.o layer.o local_layer.o shortcut_layer.o logistic_layer.o activation_layer.o rnn_layer.o gru_layer.o crnn_layer.o demo.o batchnorm_layer.o region_layer.o reorg_layer.o table.o tree.o  lstm_layer.o l2norm_layer.o yolo_layer.o iseg_layer.o image_opencv.o
 EXECOBJA=captcha.o lsd.o super.o art.o tag.o cifar.o go.o rnn.o segmenter.o regressor.o classifier.o coco.o yolo.o detector.o nightmare.o instance-segmenter.o darknet.o
 ifeq ($(GPU), 1) 
 LDFLAGS+= -lstdc++ 

--- a/examples/classifier.c
+++ b/examples/classifier.c
@@ -1,5 +1,7 @@
 #include "darknet.h"
 
+#include <table.h>
+#include <dirent.h>
 #include <sys/time.h>
 #include <assert.h>
 
@@ -557,7 +559,7 @@ void try_classifier(char *datacfg, char *cfgfile, char *weightfile, char *filena
     }
 }
 
-void predict_classifier(char *datacfg, char *cfgfile, char *weightfile, char *filename, int top)
+void predict_classifier(char *datacfg, char *cfgfile, char *weightfile, char *filename, int top, char *folder, char *csv_file)
 {
     network *net = load_network(cfgfile, weightfile, 0);
     set_batch_network(net, 1);
@@ -575,6 +577,87 @@ void predict_classifier(char *datacfg, char *cfgfile, char *weightfile, char *fi
     int *indexes = calloc(top, sizeof(int));
     char buff[256];
     char *input = buff;
+
+    if (folder) {
+        printf("\nUsing input images from %s\n", folder);
+
+        int sz = strlen(folder);
+        if (folder[sz-1] != '/') {
+            char* temp = malloc(sz + 1);
+            strcpy(temp, folder);
+            strcat(temp, "/");
+            folder = temp;
+        }
+
+        DIR *d;
+        struct dirent *dir;
+        d = opendir(folder);
+        if (d) {
+
+            int img_count = 0;
+            while ((dir = readdir(d)) != NULL) {
+                if (dir->d_name[0] == '.') continue;
+                img_count++;
+            }
+
+            table t_predictions = make_table(top + 1, img_count);
+            table t_classes = make_table(top + 1, img_count);
+
+            int j = 0;
+            d = opendir(folder);
+            while ((dir = readdir(d)) != NULL) {
+                if (dir->d_name[0] == '.') continue;
+                char* abs_filename = malloc(strlen(folder) + strlen(dir->d_name) + 1);
+                strcpy(abs_filename, folder);
+                strcat(abs_filename, dir->d_name);
+
+                strncpy(input, abs_filename, 256);
+                image im = load_image_color(input, 0, 0);
+                image r = letterbox_image(im, net->w, net->h);
+
+                float *X = r.data;
+                time = clock();
+                float *predictions = network_predict(net, X);
+                if (net->hierarchy) hierarchy_predictions(predictions, net->outputs, net->hierarchy, 1, 1);
+                top_k(predictions, net->outputs, top, indexes);
+                fprintf(stderr, "%s: Predicted in %f seconds.\n", input, sec(clock()-time));
+
+                t_predictions.vals[j] = (char *) malloc(256);
+                strcpy(t_predictions.vals[j], abs_filename + 1);
+
+                t_classes.vals[j] = (char *) malloc(256);
+                strcpy(t_classes.vals[j], abs_filename + 1);
+
+                char bf[512];
+                for (i = 0; i < top; ++i) {
+                    int index = indexes[i];
+                    printf("%5.2f%%: %s\n", predictions[index]*100, names[index]);
+
+                    int pos = (i + 1)*t_predictions.rows + j;
+                    t_predictions.vals[pos] = (char *) malloc(256);
+                    sprintf(bf, "%.50f", predictions[index]);
+                    strcpy(t_predictions.vals[pos], bf);
+
+                    t_classes.vals[pos] = (char *) malloc(256);
+                    sprintf(bf, "%s", names[index]);
+                    strcpy(t_classes.vals[pos], bf);
+                }
+
+                if (r.data != im.data) free_image(r);
+                free_image(im);
+                j++;
+            }
+            closedir(d);
+
+            table_to_csv(t_predictions, t_classes, csv_file);
+
+        } else {
+            fprintf(stderr, "%s folder does not exist!\n", folder);
+        }
+
+        return;
+    }
+
     while(1){
         if(filename){
             strncpy(input, filename, 256);
@@ -1072,13 +1155,15 @@ void run_classifier(int argc, char **argv)
     int cam_index = find_int_arg(argc, argv, "-c", 0);
     int top = find_int_arg(argc, argv, "-t", 0);
     int clear = find_arg(argc, argv, "-clear");
+    char *dataset_folder = find_char_arg(argc, argv, "-folder", 0);
+    char *csv_file = find_char_arg(argc, argv, "-csv", 0);
     char *data = argv[3];
     char *cfg = argv[4];
     char *weights = (argc > 5) ? argv[5] : 0;
     char *filename = (argc > 6) ? argv[6]: 0;
     char *layer_s = (argc > 7) ? argv[7]: 0;
     int layer = layer_s ? atoi(layer_s) : -1;
-    if(0==strcmp(argv[2], "predict")) predict_classifier(data, cfg, weights, filename, top);
+    if(0==strcmp(argv[2], "predict")) predict_classifier(data, cfg, weights, filename, top, dataset_folder, csv_file);
     else if(0==strcmp(argv[2], "fout")) file_output_classifier(data, cfg, weights, filename);
     else if(0==strcmp(argv[2], "try")) try_classifier(data, cfg, weights, filename, atoi(layer_s));
     else if(0==strcmp(argv[2], "train")) train_classifier(data, cfg, weights, gpus, ngpus, clear);

--- a/include/darknet.h
+++ b/include/darknet.h
@@ -530,6 +530,10 @@ typedef struct matrix{
     float **vals;
 } matrix;
 
+typedef struct table{
+    int rows, cols;
+    char **vals;
+} table;
 
 typedef struct{
     int w, h;
@@ -753,6 +757,7 @@ void do_nms_obj(detection *dets, int total, int classes, float thresh);
 void do_nms_sort(detection *dets, int total, int classes, float thresh);
 
 matrix make_matrix(int rows, int cols);
+table make_table(int rows, int cols);
 
 #ifdef OPENCV
 void *open_video_stream(const char *f, int c, int w, int h, int fps);

--- a/src/table.c
+++ b/src/table.c
@@ -1,0 +1,103 @@
+#include "table.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <math.h>
+
+table make_table(int rows, int cols)
+{
+    table t;
+    t.rows = rows;
+    t.cols = cols;
+    t.vals = malloc(t.rows * t.cols * sizeof(char *) * 512);
+    return t;
+}
+
+table copy_table(table t) 
+{
+    table c = {0};
+    c.rows = t.rows;
+    c.cols = t.cols;
+    c.vals = malloc(t.rows * t.cols * sizeof(char *) * 512);
+    int i, j, p;
+    for (i = 0; i < c.rows; ++i) {
+        for (j = 0; j < c.cols; ++j) {
+            p = i*c.rows + j;
+            c.vals[p] = t.vals[p];
+        } 
+    }
+    return c;
+}
+
+void table_to_csv(table t1, table t2, char *filename) 
+{
+    char *default_csv = "classifier_predictions.csv";
+    char *csv_classes;
+    
+    if (!filename) {
+        filename = default_csv;
+        csv_classes = "classifier_classes.csv";
+    } else {
+        int k = strlen(filename) - 4;
+        char *csv_ext = ".csv";
+        csv_classes = calloc(strlen(filename), sizeof(char));
+        if (k > 0) {
+            int c = 0;
+            char sub[5];
+            while (c < 4) {
+                sub[c] = filename[k + c];
+                c++;
+            }
+            sub[c] = '\0';
+            if (0!=strcmp(sub, csv_ext)) {
+                strcpy(csv_classes, filename);
+                strcat(filename, csv_ext);
+            } else {
+                strncpy(csv_classes, filename, k);
+            }
+        } else if (k == 0) {
+            strcpy(csv_classes, filename);
+            if (0!=strcmp(filename, csv_ext)) 
+                strcat(filename, csv_ext);
+        } else {
+            strcpy(csv_classes, filename);
+            strcat(filename, csv_ext);
+        }
+        
+        strcat(csv_classes, "_classes.csv");
+    }
+
+    printf("\nCSV files...\n");
+    save_csv(t1, filename);
+    save_csv(t2, csv_classes);
+}
+
+void save_csv(table t, char *filename)
+{
+    FILE *fp;
+    fp = fopen(filename, "w");
+
+    int i, j;
+    for (i = 0; i < t.rows; ++i) {
+        for (j = 0; j < t.cols; ++j) {
+            if (j > 0) fprintf(fp, ",");
+            fprintf(fp, "%s", t.vals[ i*t.rows + j ]);
+        }
+        fprintf(fp, "\n");
+    }
+
+    fclose(fp);
+    printf("%s file created!\n", filename);
+}
+
+void print_table(table t)
+{
+    int i, j;
+    for (i = 0; i < t.rows; ++i){
+        for (j = 0; j < t.cols; ++j) {
+            printf(" %s", t.vals[ i*t.rows + j ]);
+        }
+        printf("\n");
+    }
+}

--- a/src/table.h
+++ b/src/table.h
@@ -1,0 +1,10 @@
+#ifndef TABLE_H
+#define TABLE_H
+#include "darknet.h"
+
+table copy_table(table t);
+
+void table_to_csv(table t1, table t2, char *filename);
+void print_table(table t);
+
+#endif


### PR DESCRIPTION
For those who want to classifier a set of images and save all the predictions into a CSV file, I added two more options for this.

`-folder` indicates the image dataset directory path
`-csv` indicates the result file name to save the classifier predictions

Example of usage:

### `./darknet classifier predict cfg/imagenet1k.data cfg/darknet19.cfg darknet19.weights -csv -folder ./samples`

In this example `./samples` contains just three images:  _giraffe.jpg_, _dog.jpg_, and _eagle.jpg_

Adding the option `-csv` two files will be generated `classifier_predictions.csv `and `classifier_classes.csv`. 

You can even set a name to the results files, for that add this change `-csv my-results` or `-csv my-results.csv` 

Sample results...

**_classifier_predictions.csv_**
```
/samples/giraffe.jpg,/samples/dog.jpg,/samples/eagle.jpg
0.1480359733,0.4255049825,0.8467706442
0.0853090212,0.2293129861,0.1190966517
0.0698697791,0.1250679344,0.0262099374
0.0606803037,0.0276017655,0.0008274242
0.0563036576,0.0119899698,0.0007203444

```
**_classifier_classes.csv_**
```
/samples/giraffe.jpg,/samples/dog.jpg,/samples/eagle.jpg
zebra,malamute,bald eagle
ram,Eskimo dog,kite
gazelle,Siberian husky,vulture
bighorn,bicycle-built-for-two,great grey owl
bustard,mountain bike,hen
```
