### PR TITLE
Detailed README; Faulty Python path references fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,27 @@ For more information see the [Darknet project website](http://pjreddie.com/darkn
 For questions or issues please use the [Google Group](https://groups.google.com/forum/#!forum/darknet).
 
 # Usage
-## Detection
+A detailed tutorial can be found [here](http://pjreddie.com/darknet/yolov2).
+
+## Makefile
+By default, the `GPU`, `CUDNN` and `OPENCV` settings in the `Makefile` are set to `0`.
+
+In order to activate GPU and OpenCV support, change your `Makefile` settings as follows:
+```
+GPU=1
+CUDNN=1
+OPENCV=1
+...
+```
+
+Then in the `darknet` repo folder, run `make` (or `make clean && make` if you compiled the project before).
+
+## Detection (Image)
 ```
 ./darknet detect <config-file> <weights-file> <image-to-process> [-thresh <threshold>]
 ```
 
-Change paths according to description. 
-The darknet program will then process the image, output class probabilities a and using OpenCV generate a predictions.png file with bounding boxes.
-Default threshold is 25%
-
-Example:
+For example, in the darknet directory:
 ```
 ./darknet detect cfg/yolov2.cfg yolov2.weights data/dog.jpg
 ```
@@ -26,4 +37,29 @@ Alternative command:
 ```
 ./darknet detector test ...
 ```
+
+Change paths according to description.
+
+
+The darknet program will then process the image and output class probabilities. If your program was built with the OpenCV setting as `1`, it will also generate a `predictions.png` file with bounding boxes.
+
+
+The default threshold is 0.5 (50%), but you can also specify the threshold:
+```
+./darknet detector test ... -thresh 0.3
+```
+
+## Detection (Video)
+Darknet also has a demo video detector, but you will need to compile Darknet with CUDA and OpenCV. Then run the command:
+
+```
+./darknet detector demo <path_to_data_file> <path_to_config_file> <path_to_weights_file> <path_to_video_file (optional: default is webcam)>
+```
+
+For example to run on webcam,
+```
+./darknet detector demo cfg/coco.data cfg/yolov2.cfg yolov2.weights
+```
+
 ## Training
+Follow the instructions [here](https://pjreddie.com/darknet/yolov2/) for training data on [VOC](https://pjreddie.com/darknet/yolov2/#train-voc) and [COCO](https://pjreddie.com/darknet/yolov2).

--- a/README.md
+++ b/README.md
@@ -6,3 +6,24 @@ Darknet is an open source neural network framework written in C and CUDA. It is 
 For more information see the [Darknet project website](http://pjreddie.com/darknet).
 
 For questions or issues please use the [Google Group](https://groups.google.com/forum/#!forum/darknet).
+
+# Usage
+## Detection
+```
+./darknet detect <config-file> <weights-file> <image-to-process> [-thresh <threshold>]
+```
+
+Change paths according to description. 
+The darknet program will then process the image, output class probabilities a and using OpenCV generate a predictions.png file with bounding boxes.
+Default threshold is 25%
+
+Example:
+```
+./darknet detect cfg/yolov2.cfg yolov2.weights data/dog.jpg
+```
+
+Alternative command:
+```
+./darknet detector test ...
+```
+## Training

--- a/python/darknet.py
+++ b/python/darknet.py
@@ -42,10 +42,10 @@ class METADATA(Structure):
     _fields_ = [("classes", c_int),
                 ("names", POINTER(c_char_p))]
 
-    
+
 
 #lib = CDLL("/home/pjreddie/documents/darknet/libdarknet.so", RTLD_GLOBAL)
-lib = CDLL("libdarknet.so", RTLD_GLOBAL)
+lib = CDLL("../libdarknet.so", RTLD_GLOBAL)
 lib.network_width.argtypes = [c_void_p]
 lib.network_width.restype = c_int
 lib.network_height.argtypes = [c_void_p]
@@ -141,16 +141,14 @@ def detect(net, meta, image, thresh=.5, hier_thresh=.5, nms=.45):
     free_image(im)
     free_detections(dets, num)
     return res
-    
+
 if __name__ == "__main__":
     #net = load_net("cfg/densenet201.cfg", "/home/pjreddie/trained/densenet201.weights", 0)
     #im = load_image("data/wolf.jpg", 0, 0)
     #meta = load_meta("cfg/imagenet1k.data")
     #r = classify(net, meta, im)
     #print r[:10]
-    net = load_net("cfg/tiny-yolo.cfg", "tiny-yolo.weights", 0)
-    meta = load_meta("cfg/coco.data")
-    r = detect(net, meta, "data/dog.jpg")
+    net = load_net("../cfg/yolov2.cfg", "../yolov2.weights", 0)
+    meta = load_meta("../cfg/coco.data")
+    r = detect(net, meta, "../data/dog.jpg")
     print r
-    
-


### PR DESCRIPTION
Updated readme to include more detailed usage of darknet's `detector` functions.

Also fixed file/path references in `darknet.py` due to it being in the python folder and not in the main directory.