### PR TITLE
solved a bug that reading a damaged JPEG will shut the program down

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -1295,8 +1295,9 @@ image load_image_stb(char *filename, int channels)
     int w, h, c;
     unsigned char *data = stbi_load(filename, &w, &h, &c, channels);
     if (!data) {
-        fprintf(stderr, "Cannot load image \"%s\"\nSTB Reason: %s\n", filename, stbi_failure_reason());
-        exit(0);
+        fprintf(stderr, "It seems that something is wrong about the image you are loading,you will get a image in size 0*0,you can use this to skip the bad image or do something else!");
+        image i;
+        return i;
     }
     if(channels) c = channels;
     int i,j,k;


### PR DESCRIPTION
I tried to use yolo in a python socket program running on GPU that receive images returned by raspberrypi. As socket receives an image, the socket program will call darknet.py to detect the position of food in a image.But sometimes the program will exit with "STB error" and tell me that the image can't be loaded.But the JPEG image can be shown normally when i scp the image back to my PC. So I guess there must be something wrong when transport the images. I look up to the c code in src and find the function loading images,and find that if the c program can't read the image it will just exit(0). I remove exit(0) and return a empty image so I will know the image is damaged by using if(...) and I'm able to decide to skip it or what.  