### PR TITLE
Predict network with letterbox format image from cpu or gpu array

### DIFF
--- a/include/darknet.h
+++ b/include/darknet.h
@@ -636,6 +636,10 @@ void cuda_pull_array(float *x_gpu, float *x, size_t n);
 float cuda_mag_array(float *x_gpu, size_t n);
 void cuda_push_array(float *x_gpu, float *x, size_t n);
 
+float *network_predict_letterbox_gpu_device_image(network *net, image im_gpu);
+float *network_predict_gpu_device_input(network *net, float *input_gpu);
+void forward_network_gpu_device_input(network *netp);
+
 void forward_network_gpu(network *net);
 void backward_network_gpu(network *net);
 void update_network_gpu(network *net);
@@ -742,6 +746,7 @@ float *network_predict(network *net, float *input);
 int network_width(network *net);
 int network_height(network *net);
 float *network_predict_image(network *net, image im);
+float *network_predict_letterbox_image(network *net, image im);
 void network_detect(network *net, image im, float thresh, float hier_thresh, float nms, detection *dets);
 detection *get_network_boxes(network *net, int w, int h, float thresh, float hier, int *map, int relative, int *num);
 void free_detections(detection *dets, int n);

--- a/src/network.c
+++ b/src/network.c
@@ -585,6 +585,12 @@ float *network_predict_image(network *net, image im)
     return p;
 }
 
+float *network_predict_letterbox_image(network *net, image im)
+{
+    set_batch_network(net, 1);
+    return network_predict(net, im.data);
+}
+
 int network_width(network *net){return net->w;}
 int network_height(network *net){return net->h;}
 
@@ -781,6 +787,50 @@ void forward_network_gpu(network *netp)
         if(l.truth) {
             net.truth_gpu = l.output_gpu;
             net.truth = l.output;
+        }
+    }
+    pull_network_output(netp);
+    calc_network_cost(netp);
+}
+
+float *network_predict_letterbox_gpu_device_image(network *net, image im_gpu)
+{
+    set_batch_network(net, 1);
+    return network_predict_gpu_device_input(net, im_gpu.data);
+}
+
+float *network_predict_gpu_device_input(network *net, float *input_gpu)
+{
+    network orig = *net;
+    net->input_gpu = input_gpu;
+    net->truth = 0;
+    net->train = 0;
+    net->delta = 0;
+    forward_network_gpu_device_input(net);
+    float *out = net->output;
+    *net = orig;
+    return out;
+}
+
+void forward_network_gpu_device_input(network *netp)
+{
+    network net = *netp;
+    cuda_set_device(net.gpu_index);
+    if(net.truth){
+        cuda_push_array(net.truth_gpu, net.truth, net.truths*net.batch);
+    }
+
+    int i;
+    for(i = 0; i < net.n; ++i){
+        net.index = i;
+        layer l = net.layers[i];
+        if(l.delta_gpu){
+            fill_gpu(l.outputs * l.batch, 0, l.delta_gpu, 1);
+        }
+        l.forward_gpu(l, net);
+        net.input_gpu = l.output_gpu;
+        if(l.truth) {
+            net.truth_gpu = l.output_gpu;
         }
     }
     pull_network_output(netp);


### PR DESCRIPTION
Add functions to be able to predict a network using an image already in the expected letterbox format.
This image can be located in an array accessible from the cpu or gpu.