### PR TITLE
fix missing libdarknet.so

### DIFF
--- a/python/darknet.py
+++ b/python/darknet.py
@@ -1,6 +1,7 @@
 from ctypes import *
 import math
 import random
+import os
 
 def sample(probs):
     s = sum(probs)
@@ -45,7 +46,7 @@ class METADATA(Structure):
     
 
 #lib = CDLL("/home/pjreddie/documents/darknet/libdarknet.so", RTLD_GLOBAL)
-lib = CDLL("libdarknet.so", RTLD_GLOBAL)
+lib = CDLL(os.path.join(os.getcwd(), "libdarknet.so"), RTLD_GLOBAL)
 lib.network_width.argtypes = [c_void_p]
 lib.network_width.restype = c_int
 lib.network_height.argtypes = [c_void_p]


### PR DESCRIPTION
## problem
When I ran darknet.py in the python folder, I got the following error
```
Traceback (most recent call last):
  File "python/darknet.py", line 48, in <module>
    lib = CDLL("libdarknet.so", RTLD_GLOBAL)
  File "/home/mike/.pyenv/versions/3.8.2/lib/python3.8/ctypes/__init__.py", line 373, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: libdarknet.so: cannot open shared object file: No such file or directory
```

## How to fix
The target file was not loaded correctly.
Using the OS module and referring to the relative

and thx this comment 
https://github.com/pjreddie/darknet/issues/428#issuecomment-473514126
