### PR TITLE
Pass byte objects as arguments instead of strings

### DIFF
--- a/python/darknet.py
+++ b/python/darknet.py
@@ -148,7 +148,7 @@ if __name__ == "__main__":
     #meta = load_meta("cfg/imagenet1k.data")
     #r = classify(net, meta, im)
     #print r[:10]
-    net = load_net("cfg/tiny-yolo.cfg", "tiny-yolo.weights", 0)
+    net = load_net(b"cfg/tiny-yolo.cfg", b"tiny-yolo.weights", 0)
     meta = load_meta("cfg/coco.data")
     r = detect(net, meta, "data/dog.jpg")
     print(r)


### PR DESCRIPTION
converted the string arguments to byte objects using the b prefix
resolve issue no : #2609 