### PR TITLE
opencv4 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,18 @@
+#GPU=1
+#CUDNN=1
+
 GPU=0
 CUDNN=0
-OPENCV=0
+OPENCV=1
 OPENMP=0
 DEBUG=0
 
 ARCH= -gencode arch=compute_30,code=sm_30 \
       -gencode arch=compute_35,code=sm_35 \
+      -gencode arch=compute_75,code=sm_75 \
       -gencode arch=compute_50,code=[sm_50,compute_50] \
       -gencode arch=compute_52,code=[sm_52,compute_52]
+      
 #      -gencode arch=compute_20,code=[sm_20,sm_21] \ This one is deprecated?
 
 # This is what I use, uncomment if you know your arch and want to specify
@@ -19,13 +24,13 @@ ALIB=libdarknet.a
 EXEC=darknet
 OBJDIR=./obj/
 
-CC=gcc
-CPP=g++
+CC=gcc-12
+CPP=g++-12
 NVCC=nvcc 
 AR=ar
 ARFLAGS=rcs
 OPTS=-Ofast
-LDFLAGS= -lm -pthread 
+LDFLAGS= -lm -pthread
 COMMON= -Iinclude/ -Isrc/
 CFLAGS=-Wall -Wno-unused-result -Wno-unknown-pragmas -Wfatal-errors -fPIC
 
@@ -42,8 +47,8 @@ CFLAGS+=$(OPTS)
 ifeq ($(OPENCV), 1) 
 COMMON+= -DOPENCV
 CFLAGS+= -DOPENCV
-LDFLAGS+= `pkg-config --libs opencv` -lstdc++
-COMMON+= `pkg-config --cflags opencv` 
+LDFLAGS+= `pkg-config --libs opencv4` -lstdc++
+COMMON+= `pkg-config --cflags opencv4`
 endif
 
 ifeq ($(GPU), 1) 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-#GPU=1
-#CUDNN=1
-
 GPU=0
 CUDNN=0
 OPENCV=1

--- a/src/image_opencv.cpp
+++ b/src/image_opencv.cpp
@@ -2,7 +2,13 @@
 
 #include "stdio.h"
 #include "stdlib.h"
-#include "opencv2/opencv.hpp"
+
+#include "opencv4/opencv2/opencv.hpp"
+#include "opencv4/opencv2/core/types_c.h"
+#include "opencv4/opencv2/core/core_c.h"
+#include "opencv4/opencv2/videoio/legacy/constants_c.h"
+#include "opencv4/opencv2/highgui/highgui_c.h"
+
 #include "image.h"
 
 using namespace cv;
@@ -60,7 +66,7 @@ Mat image_to_mat(image im)
 
 image mat_to_image(Mat m)
 {
-    IplImage ipl = m;
+    IplImage ipl = cvIplImage(m);
     image im = ipl_to_image(&ipl);
     rgbgr_image(im);
     return im;


### PR DESCRIPTION
darknet currently only supports opencv2 which is becoming increasingly difficult to build on many platforms, archlinux in my case.
"opencv4" is the current standard for archlinux and others and it contains opencv2 as a module.

The changes in the pr are some simple "header gymnastics", use of an explicit `cvIplImage` function, and small tweaks to the Makefile.